### PR TITLE
feat: Add HTML report template for planned schedules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,11 @@ The solver optimizes using HardMediumSoftScore:
 - `POST /api/shifts/analyze-weekly`: Analyze weekly work hours
 - `GET /api/shifts/test-weekly`: Test weekly constraint calculations
 
+#### HTML Report Endpoints
+- `GET /api/shifts/demo/html`: Demo data as formatted HTML report
+- `POST /api/shifts/solve-sync/html`: Synchronous optimization with HTML report output
+- `GET /api/shifts/solve/{job_id}/html`: Get optimization results as HTML report
+
 ## Development Notes
 
 ### Dependencies
@@ -172,5 +177,8 @@ make mcp
 - `get_solve_status`: Check async job status
 - `analyze_weekly_hours`: Analyze weekly work hours
 - `test_weekly_constraints`: Test weekly constraints with demo data
+- `get_demo_schedule_html`: Get demo schedule as formatted HTML report
+- `get_schedule_html_report`: Get completed schedule as HTML report
+- `solve_schedule_sync_html`: Solve and return HTML report in one step
 
 See `MCP_SERVER.md` for detailed usage and Claude Desktop integration instructions.

--- a/api-test.http
+++ b/api-test.http
@@ -153,3 +153,74 @@ GET {{baseUrl}}/api/shifts/test-weekly
 
 ### Check ReDoc
 # GET {{baseUrl}}/redoc
+
+### HTML Report endpoints
+
+### Get demo data as HTML report
+GET {{baseUrl}}/api/shifts/demo/html
+
+### Shift optimization (synchronous) with HTML report output
+POST {{baseUrl}}/api/shifts/solve-sync/html
+Content-Type: application/json
+
+{
+  "employees": [
+    {
+      "id": "emp1",
+      "name": "John Smith",
+      "skills": ["Nurse", "CPR", "Full-time"]
+    },
+    {
+      "id": "emp2",
+      "name": "Sarah Johnson",
+      "skills": ["Nurse", "Full-time"]
+    },
+    {
+      "id": "emp3",
+      "name": "Michael Brown",
+      "skills": ["Security", "Full-time"]
+    },
+    {
+      "id": "emp4",
+      "name": "Emily Davis",
+      "skills": ["Reception", "Admin", "Part-time"]
+    }
+  ],
+  "shifts": [
+    {
+      "id": "morning_shift",
+      "start_time": "2025-06-01T08:00:00",
+      "end_time": "2025-06-01T16:00:00",
+      "required_skills": ["Nurse"],
+      "location": "Hospital",
+      "priority": 1
+    },
+    {
+      "id": "evening_shift",
+      "start_time": "2025-06-01T16:00:00",
+      "end_time": "2025-06-02T00:00:00",
+      "required_skills": ["Nurse"],
+      "location": "Hospital",
+      "priority": 2
+    },
+    {
+      "id": "security_shift",
+      "start_time": "2025-06-01T22:00:00",
+      "end_time": "2025-06-02T06:00:00",
+      "required_skills": ["Security"],
+      "location": "Hospital",
+      "priority": 3
+    },
+    {
+      "id": "reception_shift",
+      "start_time": "2025-06-01T09:00:00",
+      "end_time": "2025-06-01T13:00:00",
+      "required_skills": ["Reception"],
+      "location": "Reception",
+      "priority": 4
+    }
+  ]
+}
+
+### Get job results as HTML report (use job_id from async solve response)
+# GET {{baseUrl}}/api/shifts/solve/{job_id}/html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "typing-extensions>=4.8.0",
     "fastmcp>=0.1.0",
     "httpx>=0.25.0",
+    "jinja2>=3.1.0",
 ]
 
 [project.optional-dependencies]

--- a/src/natural_shift_planner/api/routes.py
+++ b/src/natural_shift_planner/api/routes.py
@@ -7,7 +7,9 @@ from datetime import datetime
 from typing import Optional
 
 from fastapi import HTTPException
+from fastapi.responses import HTMLResponse
 
+from ..templates.renderer import render_schedule_html
 from ..utils import create_demo_schedule
 from .analysis import analyze_weekly_hours, generate_recommendations
 from .app import app
@@ -499,3 +501,53 @@ async def partial_solve_shifts(request: PartialOptimizationRequest):
             scope_summary=scope_summary,
             message=f"Optimizing {scope_summary['shifts_to_optimize']} shifts out of {scope_summary['total_shifts_in_scope']} in scope"
         )
+
+
+# HTML Report endpoints
+@app.get("/api/shifts/demo/html", response_class=HTMLResponse)
+async def get_demo_html_report():
+    """Get demo data as HTML report"""
+    schedule = create_demo_schedule()
+    schedule_data = convert_domain_to_response(schedule)
+    score = str(schedule.score) if schedule.score else None
+    html_report = render_schedule_html(schedule_data, score)
+    return HTMLResponse(content=html_report)
+
+
+@app.get("/api/shifts/solve/{job_id}/html", response_class=HTMLResponse)
+async def get_solution_html_report(job_id: str):
+    """Get optimization result as HTML report"""
+    with job_lock:
+        if job_id not in jobs:
+            raise HTTPException(status_code=404, detail="Job not found")
+
+        job = jobs[job_id]
+
+        if job["status"] != "SOLVING_COMPLETED":
+            raise HTTPException(
+                status_code=400, 
+                detail=f"Job is not completed. Current status: {job['status']}"
+            )
+
+        solution = job["solution"]
+        schedule_data = convert_domain_to_response(solution)
+        score = str(solution.score) if solution.score else None
+        html_report = render_schedule_html(schedule_data, score)
+        return HTMLResponse(content=html_report)
+
+
+@app.post("/api/shifts/solve-sync/html", response_class=HTMLResponse)
+async def solve_shifts_sync_html(request: ShiftScheduleRequest):
+    """Shift optimization (synchronous) with HTML report output"""
+    try:
+        problem = convert_request_to_domain(request)
+        solver = solver_factory.build_solver()
+        solution = solver.solve(problem)
+
+        schedule_data = convert_domain_to_response(solution)
+        score = str(solution.score) if solution.score else None
+        html_report = render_schedule_html(schedule_data, score)
+        return HTMLResponse(content=html_report)
+
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/src/natural_shift_planner/mcp/server.py
+++ b/src/natural_shift_planner/mcp/server.py
@@ -7,6 +7,8 @@ from .tools import (
     analyze_change_impact,
     analyze_weekly_hours,
     get_demo_schedule,
+    get_demo_schedule_html,
+    get_schedule_html_report,
     get_schedule_shifts,
     get_solve_status,
     health_check,
@@ -16,6 +18,7 @@ from .tools import (
     quick_fix_schedule,
     solve_schedule_async,
     solve_schedule_sync,
+    solve_schedule_sync_html,
     test_weekly_constraints,
 )
 
@@ -38,6 +41,11 @@ mcp.tool()(analyze_change_impact)
 mcp.tool()(partial_optimize_schedule)
 mcp.tool()(get_schedule_shifts)
 mcp.tool()(quick_fix_schedule)
+
+# Register HTML report tools
+mcp.tool()(get_demo_schedule_html)
+mcp.tool()(get_schedule_html_report)
+mcp.tool()(solve_schedule_sync_html)
 
 # Add prompts
 @mcp.prompt()
@@ -77,6 +85,11 @@ async def shift_scheduling_prompt() -> str:
 - partial_optimize_schedule: Re-optimize only specific parts of schedule
 - get_schedule_shifts: Inspect completed schedules
 - quick_fix_schedule: Rapidly fix common issues in focused date ranges
+
+### HTML Reports (NEW!)
+- get_demo_schedule_html: Get demo schedule as formatted HTML report
+- get_schedule_html_report: Get completed schedule as HTML report
+- solve_schedule_sync_html: Solve and return HTML report in one step
 
 ## Constraint Guidelines
 - Employee skills must match shift requirements

--- a/src/natural_shift_planner/templates/__init__.py
+++ b/src/natural_shift_planner/templates/__init__.py
@@ -1,0 +1,3 @@
+"""
+Templates module for HTML report generation
+"""

--- a/src/natural_shift_planner/templates/renderer.py
+++ b/src/natural_shift_planner/templates/renderer.py
@@ -1,0 +1,121 @@
+"""
+HTML template renderer for schedule reports
+"""
+import os
+from datetime import datetime
+from typing import Any, Dict
+
+from jinja2 import Environment, FileSystemLoader
+
+
+def format_datetime(dt_str: str) -> str:
+    """Format datetime string for display"""
+    try:
+        dt = datetime.fromisoformat(dt_str.replace('Z', '+00:00'))
+        return dt.strftime('%Y-%m-%d %H:%M')
+    except Exception:
+        return dt_str
+
+
+def format_time(dt_str: str) -> str:
+    """Format time string for display"""
+    try:
+        dt = datetime.fromisoformat(dt_str.replace('Z', '+00:00'))
+        return dt.strftime('%H:%M')
+    except Exception:
+        return dt_str
+
+
+def calculate_duration_hours(start_time: str, end_time: str) -> str:
+    """Calculate duration in hours between start and end times"""
+    try:
+        start = datetime.fromisoformat(start_time.replace('Z', '+00:00'))
+        end = datetime.fromisoformat(end_time.replace('Z', '+00:00'))
+        duration = end - start
+        hours = duration.total_seconds() / 3600
+        return f"{hours:.1f}"
+    except Exception:
+        return "N/A"
+
+
+def get_priority_class(priority: int) -> str:
+    """Get CSS class for priority level"""
+    if priority <= 3:
+        return "high"
+    elif priority <= 7:
+        return "medium"
+    else:
+        return "low"
+
+
+class ScheduleReportRenderer:
+    """HTML report renderer for shift schedules"""
+    
+    def __init__(self):
+        # Get the templates directory path
+        templates_dir = os.path.dirname(os.path.abspath(__file__))
+        
+        # Set up Jinja2 environment
+        self.env = Environment(
+            loader=FileSystemLoader(templates_dir),
+            autoescape=True
+        )
+        
+        # Add custom filters
+        self.env.filters['format_datetime'] = format_datetime
+        self.env.filters['format_time'] = format_time
+    
+    def render_schedule_report(self, schedule_data: Dict[str, Any], score: str = None) -> str:
+        """
+        Render schedule data as HTML report
+        
+        Args:
+            schedule_data: Schedule data from convert_domain_to_response
+            score: Optional optimization score
+            
+        Returns:
+            HTML string
+        """
+        # Get the template
+        template = self.env.get_template('schedule_report.html')
+        
+        # Process shifts to add calculated fields
+        processed_shifts = []
+        for shift in schedule_data.get('shifts', []):
+            processed_shift = shift.copy()
+            processed_shift['duration_hours'] = calculate_duration_hours(
+                shift['start_time'], 
+                shift['end_time']
+            )
+            processed_shift['priority_class'] = get_priority_class(shift['priority'])
+            processed_shifts.append(processed_shift)
+        
+        # Prepare template context
+        context = {
+            'timestamp': datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
+            'employees': schedule_data.get('employees', []),
+            'shifts': processed_shifts,
+            'statistics': schedule_data.get('statistics', {}),
+            'score': score
+        }
+        
+        # Render and return HTML
+        return template.render(**context)
+
+
+# Create a singleton instance
+renderer = ScheduleReportRenderer()
+
+
+def render_schedule_html(schedule_data: Dict[str, Any], score: str = None) -> str:
+    """
+    Convenience function to render schedule data as HTML
+    
+    Args:
+        schedule_data: Schedule data from convert_domain_to_response
+        score: Optional optimization score
+        
+    Returns:
+        HTML string
+    """
+    return renderer.render_schedule_report(schedule_data, score)

--- a/src/natural_shift_planner/templates/schedule_report.html
+++ b/src/natural_shift_planner/templates/schedule_report.html
@@ -1,0 +1,297 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Shift Schedule Report</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Arial, sans-serif;
+            line-height: 1.6;
+            margin: 0;
+            padding: 20px;
+            background-color: #f5f5f5;
+        }
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            background: white;
+            border-radius: 8px;
+            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+            overflow: hidden;
+        }
+        .header {
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            padding: 30px;
+            text-align: center;
+        }
+        .header h1 {
+            margin: 0 0 10px 0;
+            font-size: 2.5em;
+            font-weight: 300;
+        }
+        .header .subtitle {
+            font-size: 1.1em;
+            opacity: 0.9;
+        }
+        .stats-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 20px;
+            padding: 30px;
+            background: #f8f9fa;
+        }
+        .stat-card {
+            background: white;
+            padding: 20px;
+            border-radius: 8px;
+            text-align: center;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .stat-value {
+            font-size: 2.5em;
+            font-weight: bold;
+            color: #667eea;
+            margin-bottom: 5px;
+        }
+        .stat-label {
+            color: #6c757d;
+            font-size: 0.9em;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+        }
+        .section {
+            padding: 30px;
+        }
+        .section h2 {
+            margin-top: 0;
+            color: #495057;
+            border-bottom: 3px solid #667eea;
+            padding-bottom: 10px;
+            font-weight: 600;
+        }
+        .employees-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+            gap: 20px;
+            margin-top: 20px;
+        }
+        .employee-card {
+            background: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 8px;
+            padding: 20px;
+        }
+        .employee-name {
+            font-weight: bold;
+            font-size: 1.1em;
+            color: #495057;
+            margin-bottom: 10px;
+        }
+        .employee-skills {
+            margin-bottom: 15px;
+        }
+        .skill-tag {
+            display: inline-block;
+            background: #e3f2fd;
+            color: #1976d2;
+            padding: 3px 8px;
+            border-radius: 12px;
+            font-size: 0.8em;
+            margin: 2px;
+        }
+        .schedule-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 20px;
+        }
+        .schedule-table th,
+        .schedule-table td {
+            padding: 12px;
+            text-align: left;
+            border-bottom: 1px solid #dee2e6;
+        }
+        .schedule-table th {
+            background: #f8f9fa;
+            font-weight: 600;
+            color: #495057;
+            position: sticky;
+            top: 0;
+        }
+        .schedule-table tr:hover {
+            background: #f8f9fa;
+        }
+        .time-badge {
+            background: #e8f5e8;
+            color: #28a745;
+            padding: 4px 8px;
+            border-radius: 4px;
+            font-size: 0.85em;
+            font-weight: 500;
+        }
+        .location-badge {
+            background: #fff3cd;
+            color: #856404;
+            padding: 4px 8px;
+            border-radius: 4px;
+            font-size: 0.85em;
+        }
+        .priority-badge {
+            padding: 4px 8px;
+            border-radius: 4px;
+            font-size: 0.85em;
+            font-weight: 500;
+        }
+        .priority-high { background: #f8d7da; color: #721c24; }
+        .priority-medium { background: #fff3cd; color: #856404; }
+        .priority-low { background: #d1ecf1; color: #0c5460; }
+        .unassigned {
+            color: #dc3545;
+            font-style: italic;
+        }
+        .assigned {
+            color: #28a745;
+            font-weight: 500;
+        }
+        .footer {
+            background: #f8f9fa;
+            text-align: center;
+            padding: 20px;
+            color: #6c757d;
+            border-top: 1px solid #dee2e6;
+        }
+        @media (max-width: 768px) {
+            .container {
+                margin: 10px;
+                border-radius: 0;
+            }
+            .header {
+                padding: 20px;
+            }
+            .header h1 {
+                font-size: 2em;
+            }
+            .stats-grid {
+                grid-template-columns: repeat(2, 1fr);
+                padding: 20px;
+                gap: 15px;
+            }
+            .section {
+                padding: 20px;
+            }
+            .employees-grid {
+                grid-template-columns: 1fr;
+            }
+            .schedule-table {
+                font-size: 0.9em;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>Shift Schedule Report</h1>
+            <div class="subtitle">Generated on {{ timestamp }}</div>
+        </div>
+
+        <div class="stats-grid">
+            <div class="stat-card">
+                <div class="stat-value">{{ statistics.total_employees }}</div>
+                <div class="stat-label">Total Employees</div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-value">{{ statistics.total_shifts }}</div>
+                <div class="stat-label">Total Shifts</div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-value">{{ statistics.assigned_shifts }}</div>
+                <div class="stat-label">Assigned Shifts</div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-value">{{ statistics.unassigned_shifts }}</div>
+                <div class="stat-label">Unassigned Shifts</div>
+            </div>
+        </div>
+
+        <div class="section">
+            <h2>📋 Employees Overview</h2>
+            <div class="employees-grid">
+                {% for employee in employees %}
+                <div class="employee-card">
+                    <div class="employee-name">{{ employee.name }} ({{ employee.id }})</div>
+                    <div class="employee-skills">
+                        <strong>Skills:</strong>
+                        {% for skill in employee.skills %}
+                        <span class="skill-tag">{{ skill }}</span>
+                        {% endfor %}
+                    </div>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+
+        <div class="section">
+            <h2>📅 Shift Schedule</h2>
+            <div style="overflow-x: auto;">
+                <table class="schedule-table">
+                    <thead>
+                        <tr>
+                            <th>Shift ID</th>
+                            <th>Date & Time</th>
+                            <th>Duration</th>
+                            <th>Required Skills</th>
+                            <th>Location</th>
+                            <th>Priority</th>
+                            <th>Assigned Employee</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for shift in shifts %}
+                        <tr>
+                            <td><strong>{{ shift.id }}</strong></td>
+                            <td>
+                                <div class="time-badge">
+                                    {{ shift.start_time|format_datetime }} - {{ shift.end_time|format_time }}
+                                </div>
+                            </td>
+                            <td>{{ shift.duration_hours }}h</td>
+                            <td>
+                                {% for skill in shift.required_skills %}
+                                <span class="skill-tag">{{ skill }}</span>
+                                {% endfor %}
+                            </td>
+                            <td>
+                                {% if shift.location %}
+                                <span class="location-badge">{{ shift.location }}</span>
+                                {% else %}
+                                <span style="color: #6c757d;">-</span>
+                                {% endif %}
+                            </td>
+                            <td>
+                                <span class="priority-badge priority-{{ shift.priority_class }}">
+                                    {{ shift.priority }}
+                                </span>
+                            </td>
+                            <td>
+                                {% if shift.employee %}
+                                <span class="assigned">{{ shift.employee.name }}</span>
+                                {% else %}
+                                <span class="unassigned">Unassigned</span>
+                                {% endif %}
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <div class="footer">
+            <p>Report generated by Natural Shift Planner | 
+            Optimization Score: <strong>{{ score or 'N/A' }}</strong></p>
+        </div>
+    </div>
+</body>
+</html>

--- a/tests/test_html_reports.py
+++ b/tests/test_html_reports.py
@@ -1,0 +1,138 @@
+"""
+Tests for HTML report generation
+"""
+import pytest
+from datetime import datetime
+
+from src.natural_shift_planner.templates.renderer import render_schedule_html
+
+
+def test_render_schedule_html():
+    """Test HTML report rendering with sample data"""
+    # Sample schedule data that matches the API response format
+    schedule_data = {
+        "employees": [
+            {
+                "id": "emp1",
+                "name": "Alice Smith",
+                "skills": ["cashier", "customer_service"]
+            },
+            {
+                "id": "emp2", 
+                "name": "Bob Johnson",
+                "skills": ["cook", "kitchen_prep"]
+            }
+        ],
+        "shifts": [
+            {
+                "id": "shift1",
+                "start_time": "2024-01-15T09:00:00",
+                "end_time": "2024-01-15T17:00:00",
+                "required_skills": ["cashier"],
+                "location": "Front Desk",
+                "priority": 3,
+                "employee": {
+                    "id": "emp1",
+                    "name": "Alice Smith"
+                }
+            },
+            {
+                "id": "shift2",
+                "start_time": "2024-01-15T10:00:00",
+                "end_time": "2024-01-15T18:00:00", 
+                "required_skills": ["cook"],
+                "location": "Kitchen",
+                "priority": 5,
+                "employee": {
+                    "id": "emp2",
+                    "name": "Bob Johnson"
+                }
+            },
+            {
+                "id": "shift3",
+                "start_time": "2024-01-15T14:00:00",
+                "end_time": "2024-01-15T22:00:00",
+                "required_skills": ["cashier"],
+                "location": "Front Desk",
+                "priority": 7,
+                "employee": None  # Unassigned
+            }
+        ],
+        "statistics": {
+            "total_employees": 2,
+            "total_shifts": 3,
+            "assigned_shifts": 2,
+            "unassigned_shifts": 1
+        }
+    }
+    
+    # Render HTML
+    html = render_schedule_html(schedule_data, score="0hard/0medium/0soft")
+    
+    # Basic structure checks
+    assert "<!DOCTYPE html>" in html
+    assert "<title>Shift Schedule Report</title>" in html
+    assert "Alice Smith" in html
+    assert "Bob Johnson" in html
+    assert "Front Desk" in html
+    assert "Kitchen" in html
+    assert "cashier" in html
+    assert "cook" in html
+    assert "Unassigned" in html
+    
+    # Statistics check
+    assert "2" in html  # total employees
+    assert "3" in html  # total shifts
+    
+    # CSS and styling
+    assert "font-family:" in html
+    assert ".container" in html
+    assert ".stat-card" in html
+    
+    # Responsive design
+    assert "@media (max-width: 768px)" in html
+
+
+def test_render_empty_schedule():
+    """Test rendering with minimal data"""
+    schedule_data = {
+        "employees": [],
+        "shifts": [],
+        "statistics": {
+            "total_employees": 0,
+            "total_shifts": 0,
+            "assigned_shifts": 0,
+            "unassigned_shifts": 0
+        }
+    }
+    
+    html = render_schedule_html(schedule_data)
+    
+    # Should still render properly
+    assert "<!DOCTYPE html>" in html
+    assert "Shift Schedule Report" in html
+    assert "0" in html  # zero statistics
+
+
+def test_render_with_score():
+    """Test rendering with optimization score"""
+    schedule_data = {
+        "employees": [],
+        "shifts": [],
+        "statistics": {
+            "total_employees": 0,
+            "total_shifts": 0,
+            "assigned_shifts": 0,
+            "unassigned_shifts": 0
+        }
+    }
+    
+    score = "5hard/10medium/15soft"
+    html = render_schedule_html(schedule_data, score)
+    
+    assert score in html
+    assert "Optimization Score:" in html
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
Implements #10 - Add HTML report template functionality

## Summary
- Addresses the LLM report formatting inconsistency issue
- Adds responsive HTML template with professional styling
- Integrates 3 new API endpoints for HTML reports
- Includes MCP server integration for AI assistants

## Changes
- Added `templates/` module with Jinja2 renderer
- New API endpoints: `/api/shifts/demo/html`, `/api/shifts/solve-sync/html`, `/api/shifts/solve/{job_id}/html`
- Updated MCP tools to support HTML report generation
- Added Jinja2 dependency to pyproject.toml
- Included comprehensive tests and API examples

## Benefits
- Consistent report formatting eliminates LLM variance
- Professional, responsive design for better readability
- Easy integration with AI assistants via MCP tools

Generated with [Claude Code](https://claude.ai/code)