### PR TITLE
Fix 'Illegal Capacity: -4' error in Employee methods

### DIFF
--- a/src/natural_shift_planner/core/models/employee.py
+++ b/src/natural_shift_planner/core/models/employee.py
@@ -35,19 +35,44 @@ class Employee:
 
     def prefers_day_off(self, day_name: str) -> bool:
         """Check if employee prefers this day off"""
-        return day_name.lower() in {day.lower() for day in self.preferred_days_off}
+        if self.preferred_days_off is None or len(self.preferred_days_off) == 0:
+            return False
+        day_lower = day_name.lower()
+        for pref_day in self.preferred_days_off:
+            if pref_day is not None and pref_day.lower() == day_lower:
+                return True
+        return False
 
     def prefers_work_day(self, day_name: str) -> bool:
         """Check if employee prefers to work on this day"""
-        return day_name.lower() in {day.lower() for day in self.preferred_work_days}
+        if self.preferred_work_days is None or len(self.preferred_work_days) == 0:
+            return False
+        day_lower = day_name.lower()
+        for pref_day in self.preferred_work_days:
+            if pref_day is not None and pref_day.lower() == day_lower:
+                return True
+        return False
 
     def is_unavailable_on_date(self, date: datetime) -> bool:
         """Check if employee is unavailable on a specific date"""
+        # Handle None or empty unavailable_dates safely
+        if self.unavailable_dates is None or len(self.unavailable_dates) == 0:
+            return False
+        
+        # Normalize the input date to date-only (remove time components)
         date_only = date.replace(hour=0, minute=0, second=0, microsecond=0)
-        return any(
-            unavailable.replace(hour=0, minute=0, second=0, microsecond=0) == date_only
-            for unavailable in self.unavailable_dates
-        )
+        
+        # Check each unavailable date explicitly to avoid generator expression issues
+        for unavailable_date in self.unavailable_dates:
+            if unavailable_date is None:
+                continue
+            unavailable_only = unavailable_date.replace(
+                hour=0, minute=0, second=0, microsecond=0
+            )
+            if unavailable_only == date_only:
+                return True
+        
+        return False
 
     def __str__(self):
         return f"Employee(id='{self.id}', name='{self.name}', skills={self.skills})"


### PR DESCRIPTION
## Summary
- Fixed "Illegal Capacity: -4" error occurring in Employee.is_unavailable_on_date() method
- Replaced Python generator expressions with explicit for loops to avoid Timefold Java interop issues
- Added comprehensive null/empty checks for safety

## Technical Details
The error was caused by jpyinterpreter compatibility issues when Timefold processes Python generator expressions. The solution replaces:
```python
return any(
    unavailable.replace(hour=0, minute=0, second=0, microsecond=0) == date_only
    for unavailable in self.unavailable_dates
)
```

With explicit iteration:
```python
for unavailable_date in self.unavailable_dates:
    if unavailable_date is None:
        continue
    unavailable_only = unavailable_date.replace(hour=0, minute=0, second=0, microsecond=0)
    if unavailable_only == date_only:
        return True
return False
```

## Files Changed
- `src/natural_shift_planner/core/models/employee.py`: Fixed is_unavailable_on_date() method

## Test Plan
- [x] Verify demo data loads without errors
- [x] Test optimization runs without "Illegal Capacity" errors
- [x] Ensure unavailable dates constraint still works correctly

Fixes #23

🤖 Generated with [Claude Code](https://claude.ai/code)