### PR TITLE
Remove obsolete quick_fix_schedule MCP tool

### DIFF
--- a/src/natural_shift_planner/mcp/server.py
+++ b/src/natural_shift_planner/mcp/server.py
@@ -16,7 +16,6 @@ from .tools import (
     get_solve_status,
     health_check,
     pin_shifts,
-    quick_fix_schedule,
     reassign_shift,
     solve_schedule_async,
     solve_schedule_sync,
@@ -40,7 +39,6 @@ mcp.tool()(test_weekly_constraints)
 
 # Register remaining tools
 mcp.tool()(get_schedule_shifts)
-mcp.tool()(quick_fix_schedule)
 
 # Register HTML report tools
 mcp.tool()(get_demo_schedule_html)
@@ -86,7 +84,6 @@ async def shift_scheduling_prompt() -> str:
 
 ### Schedule Inspection
 - get_schedule_shifts: Inspect completed schedules
-- quick_fix_schedule: Rapidly fix common issues in focused date ranges
 
 ### Continuous Planning (Real-time Modifications)
 - swap_shifts: Swap employees between two shifts during optimization

--- a/src/natural_shift_planner/mcp/tools.py
+++ b/src/natural_shift_planner/mcp/tools.py
@@ -179,34 +179,6 @@ async def get_schedule_shifts(ctx: Context, job_id: str) -> Dict[str, Any]:
     return await call_api("GET", f"/api/shifts/solve/{job_id}")
 
 
-async def quick_fix_schedule(
-    ctx: Context, base_schedule_id: str, issues: List[str], date_range_days: int = 7
-) -> Dict[str, Any]:
-    """
-    Quick fix common scheduling issues using partial optimization
-
-    Args:
-        base_schedule_id: ID of the existing schedule
-        issues: List of issues to fix ("overtime", "unassigned", "skills")
-        date_range_days: Number of days to optimize (from today)
-
-    Returns:
-        Optimization result focusing on fixing specified issues
-    """
-    from datetime import datetime, timedelta
-
-    today = datetime.now().date()
-    end_date = today + timedelta(days=date_range_days)
-
-    # Use partial optimization with focused scope
-    return await partial_optimize_schedule(
-        ctx,
-        base_schedule_id=base_schedule_id,
-        start_date=today.isoformat(),
-        end_date=end_date.isoformat(),
-        preserve_locked=True,
-        minimize_changes=True,
-    )
 
 
 # HTML Report tools


### PR DESCRIPTION
## Summary
Removes the obsolete `quick_fix_schedule` MCP tool that was referencing non-existent API functionality.

## Problem
The `quick_fix_schedule` function was attempting to call `partial_optimize_schedule`, which doesn't exist in the current API. This was leftover code from PR #7 functionality that was removed in Issue #18.

## Solution
- ✅ Removed `quick_fix_schedule` function from `mcp/tools.py`
- ✅ Updated MCP server imports to remove the obsolete tool
- ✅ Removed tool registration from MCP server
- ✅ Updated prompt documentation to remove references
- ✅ Verified all continuous planning tools remain functional

## Impact
- **Total MCP tools**: 19 → 18 (removed 1 obsolete tool)
- **Continuous planning tools**: All 4 tools remain functional and available
- **API compatibility**: No breaking changes to existing functionality
- **Error prevention**: Eliminates potential runtime errors from undefined function calls

## Testing Results
- ✅ MCP server starts successfully with 18 tools
- ✅ `quick_fix_schedule` successfully removed from tool list
- ✅ All continuous planning tools verified as present and functional:
  - `swap_shifts`
  - `find_shift_replacement` 
  - `pin_shifts`
  - `reassign_shift`

## Files Changed
- `src/natural_shift_planner/mcp/tools.py`: Removed obsolete function
- `src/natural_shift_planner/mcp/server.py`: Updated imports, registration, and documentation

This cleanup ensures the MCP server only exposes functional, well-defined tools to AI assistants.

🤖 Generated with [Claude Code](https://claude.ai/code)