### PR TITLE
Remove obsolete quick_fix_schedule MCP tool

### DIFF
--- a/src/natural_shift_planner/mcp/server.py
+++ b/src/natural_shift_planner/mcp/server.py
@@ -16,7 +16,6 @@ from .tools import (
     get_solve_status,
     health_check,
     pin_shifts,
-    quick_fix_schedule,
     reassign_shift,
     solve_schedule_async,
     solve_schedule_sync,
@@ -40,7 +39,6 @@ mcp.tool()(test_weekly_constraints)
 
 # Register remaining tools
 mcp.tool()(get_schedule_shifts)
-mcp.tool()(quick_fix_schedule)
 
 # Register HTML report tools
 mcp.tool()(get_demo_schedule_html)
@@ -86,7 +84,6 @@ async def shift_scheduling_prompt() -> str:
 
 ### Schedule Inspection
 - get_schedule_shifts: Inspect completed schedules
-- quick_fix_schedule: Rapidly fix common issues in focused date ranges
 
 ### Continuous Planning (Real-time Modifications)
 - swap_shifts: Swap employees between two shifts during optimization

--- a/src/natural_shift_planner/mcp/tools.py
+++ b/src/natural_shift_planner/mcp/tools.py
@@ -179,36 +179,6 @@ async def get_schedule_shifts(ctx: Context, job_id: str) -> Dict[str, Any]:
     return await call_api("GET", f"/api/shifts/solve/{job_id}")
 
 
-async def quick_fix_schedule(
-    ctx: Context, base_schedule_id: str, issues: List[str], date_range_days: int = 7
-) -> Dict[str, Any]:
-    """
-    Quick fix common scheduling issues using partial optimization
-
-    Args:
-        base_schedule_id: ID of the existing schedule
-        issues: List of issues to fix ("overtime", "unassigned", "skills")
-        date_range_days: Number of days to optimize (from today)
-
-    Returns:
-        Optimization result focusing on fixing specified issues
-    """
-    from datetime import datetime, timedelta
-
-    today = datetime.now().date()
-    end_date = today + timedelta(days=date_range_days)
-
-    # Use partial optimization with focused scope
-    return await partial_optimize_schedule(
-        ctx,
-        base_schedule_id=base_schedule_id,
-        start_date=today.isoformat(),
-        end_date=end_date.isoformat(),
-        preserve_locked=True,
-        minimize_changes=True,
-    )
-
-
 # HTML Report tools
 async def call_api_html(endpoint: str, timeout: float = 120.0) -> str:
     """Make an API call that returns HTML content"""


### PR DESCRIPTION
- Removed quick_fix_schedule function that referenced non-existent partial_optimize_schedule API
- This was leftover from PR #7 functionality that was removed in Issue #18
- Updated MCP server imports and registrations
- Updated prompt documentation to remove references
- Total MCP tools now: 18 (down from 19)

🤖 Generated with [Claude Code](https://claude.ai/code)