### PR TITLE
feat: add job_id parameter to continuous planning endpoints

### DIFF
--- a/api-test.http
+++ b/api-test.http
@@ -226,9 +226,10 @@ Content-Type: application/json
 # GET {{baseUrl}}/api/shifts/solve/{job_id}/html
 
 ### Continuous Planning endpoints
+# NOTE: Replace {job_id} with an actual job ID from a completed async solve operation
 
 ### Swap shifts between two employees
-POST {{baseUrl}}/api/shifts/swap
+POST {{baseUrl}}/api/shifts/{job_id}/swap
 Content-Type: application/json
 
 {
@@ -237,7 +238,7 @@ Content-Type: application/json
 }
 
 ### Find replacement for a shift
-POST {{baseUrl}}/api/shifts/replace
+POST {{baseUrl}}/api/shifts/{job_id}/replace
 Content-Type: application/json
 
 {
@@ -247,7 +248,7 @@ Content-Type: application/json
 }
 
 ### Pin shifts to prevent changes
-POST {{baseUrl}}/api/shifts/pin
+POST {{baseUrl}}/api/shifts/{job_id}/pin
 Content-Type: application/json
 
 {
@@ -256,7 +257,7 @@ Content-Type: application/json
 }
 
 ### Unpin shifts to allow changes
-POST {{baseUrl}}/api/shifts/pin
+POST {{baseUrl}}/api/shifts/{job_id}/pin
 Content-Type: application/json
 
 {
@@ -265,7 +266,7 @@ Content-Type: application/json
 }
 
 ### Reassign a shift to specific employee
-POST {{baseUrl}}/api/shifts/reassign
+POST {{baseUrl}}/api/shifts/{job_id}/reassign
 Content-Type: application/json
 
 {
@@ -274,7 +275,7 @@ Content-Type: application/json
 }
 
 ### Reassign a shift to unassigned
-POST {{baseUrl}}/api/shifts/reassign
+POST {{baseUrl}}/api/shifts/{job_id}/reassign
 Content-Type: application/json
 
 {

--- a/src/natural_shift_planner/mcp/tools.py
+++ b/src/natural_shift_planner/mcp/tools.py
@@ -265,11 +265,12 @@ class ShiftReassignRequest(BaseModel):
     new_employee_id: Optional[str] = Field(None, description="ID of new employee (None to unassign)")
 
 
-async def swap_shifts(ctx: Context, shift1_id: str, shift2_id: str) -> Dict[str, Any]:
+async def swap_shifts(ctx: Context, job_id: str, shift1_id: str, shift2_id: str) -> Dict[str, Any]:
     """
     Swap employees between two shifts during continuous planning
     
     Args:
+        job_id: ID of the active optimization job
         shift1_id: ID of the first shift
         shift2_id: ID of the second shift
     
@@ -280,11 +281,12 @@ async def swap_shifts(ctx: Context, shift1_id: str, shift2_id: str) -> Dict[str,
         "shift1_id": shift1_id,
         "shift2_id": shift2_id
     }
-    return await call_api("POST", "/api/shifts/swap", request_data)
+    return await call_api("POST", f"/api/shifts/{job_id}/swap", request_data)
 
 
 async def find_shift_replacement(
     ctx: Context, 
+    job_id: str,
     shift_id: str, 
     unavailable_employee_id: str, 
     excluded_employee_ids: Optional[List[str]] = None
@@ -293,6 +295,7 @@ async def find_shift_replacement(
     Find replacement for a shift when an employee becomes unavailable
     
     Args:
+        job_id: ID of the active optimization job
         shift_id: ID of the shift needing replacement
         unavailable_employee_id: ID of the employee who cannot work
         excluded_employee_ids: Additional employees to exclude from consideration
@@ -305,11 +308,12 @@ async def find_shift_replacement(
         "unavailable_employee_id": unavailable_employee_id,
         "excluded_employee_ids": excluded_employee_ids or []
     }
-    return await call_api("POST", "/api/shifts/replace", request_data)
+    return await call_api("POST", f"/api/shifts/{job_id}/replace", request_data)
 
 
 async def pin_shifts(
     ctx: Context, 
+    job_id: str,
     shift_ids: List[str], 
     action: str = "pin"
 ) -> Dict[str, Any]:
@@ -317,6 +321,7 @@ async def pin_shifts(
     Pin or unpin shifts to prevent changes during optimization
     
     Args:
+        job_id: ID of the active optimization job
         shift_ids: List of shift IDs to pin/unpin
         action: Either "pin" or "unpin"
     
@@ -330,11 +335,12 @@ async def pin_shifts(
         "shift_ids": shift_ids,
         "action": action
     }
-    return await call_api("POST", "/api/shifts/pin", request_data)
+    return await call_api("POST", f"/api/shifts/{job_id}/pin", request_data)
 
 
 async def reassign_shift(
     ctx: Context, 
+    job_id: str,
     shift_id: str, 
     new_employee_id: Optional[str] = None
 ) -> Dict[str, Any]:
@@ -342,6 +348,7 @@ async def reassign_shift(
     Reassign a shift to a specific employee or unassign it
     
     Args:
+        job_id: ID of the active optimization job
         shift_id: ID of the shift to reassign
         new_employee_id: ID of new employee (None to unassign)
     
@@ -352,7 +359,7 @@ async def reassign_shift(
         "shift_id": shift_id,
         "new_employee_id": new_employee_id
     }
-    return await call_api("POST", "/api/shifts/reassign", request_data)
+    return await call_api("POST", f"/api/shifts/{job_id}/reassign", request_data)
 
 
 # PDF Report tools


### PR DESCRIPTION
## Summary

- Fix missing `job_id` parameter in continuous planning endpoints
- Update API routes to use `{job_id}` path parameter for consistency
- Update MCP tools and API tests to match new endpoint format

This addresses issue #31 by making continuous planning operations target specific optimization jobs rather than searching for any active job.

## Changes Made

### API Endpoints (routes.py)
- Changed `/api/shifts/swap` → `/api/shifts/{job_id}/swap`
- Changed `/api/shifts/replace` → `/api/shifts/{job_id}/replace`
- Changed `/api/shifts/pin` → `/api/shifts/{job_id}/pin`
- Changed `/api/shifts/reassign` → `/api/shifts/{job_id}/reassign`

### MCP Tools (mcp/tools.py)
- Updated all 4 continuous planning functions to accept `job_id` parameter
- Updated API endpoints called by MCP tools

### API Tests (api-test.http)
- Updated test requests to use new endpoint format
- Added helpful comments for usage

## Breaking Change

⚠️ This is a breaking change as the API endpoints now require a `job_id` path parameter, but this is necessary for proper functionality.

## Test Plan

- [ ] Start async optimization job: `POST /api/shifts/solve`
- [ ] Use returned job_id with continuous planning endpoints
- [ ] Verify job validation works correctly
- [ ] Test MCP tools with new job_id parameter

Fixes #31

Generated with [Claude Code](https://claude.ai/code)