### PR TITLE
docs: fix API endpoints and create comprehensive MCP documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,5 +190,8 @@ make mcp
 - `get_demo_schedule_html`: Get demo schedule as formatted HTML report
 - `get_schedule_html_report`: Get completed schedule as HTML report
 - `solve_schedule_sync_html`: Solve and return HTML report in one step
+- `get_demo_schedule_pdf`: Get demo schedule as PDF report
+- `get_schedule_pdf_report`: Get completed schedule as PDF report
+- `solve_schedule_sync_pdf`: Solve and return PDF report in one step
 
 See `MCP_SERVER.md` for detailed usage and Claude Desktop integration instructions.

--- a/MCP_SERVER.md
+++ b/MCP_SERVER.md
@@ -1,0 +1,220 @@
+# MCP Server for Natural Shift Planner
+
+This document provides detailed setup and usage instructions for the Model Context Protocol (MCP) server that exposes the Shift Scheduler API functionality to AI assistants like Claude Desktop.
+
+## 🚀 Quick Start
+
+### Prerequisites
+- Natural Shift Planner API running on `http://localhost:8081`
+- Claude Desktop or another MCP-compatible AI assistant
+- Python 3.11+ with FastMCP installed
+
+### 1. Start the MCP Server
+
+```bash
+# Run both API and MCP servers together (recommended)
+make run-mcp
+
+# Or run them separately:
+make run      # Terminal 1: API server (port 8081)
+make mcp      # Terminal 2: MCP server (stdio)
+```
+
+### 2. Claude Desktop Configuration
+
+Add this configuration to your Claude Desktop config file:
+
+**macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+**Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "shift-scheduler": {
+      "command": "uv",
+      "args": ["run", "--project", "/path/to/natural-shift-planner", "python", "/path/to/natural-shift-planner/mcp_server.py"],
+      "env": {
+        "SHIFT_SCHEDULER_API_URL": "http://localhost:8081"
+      }
+    }
+  }
+}
+```
+
+**Important**: Replace `/path/to/natural-shift-planner` with the actual absolute path to your project directory.
+
+### 3. Restart Claude Desktop
+
+After updating the configuration, restart Claude Desktop for the changes to take effect. You should see the shift scheduler tools available in Claude Desktop.
+
+## 🛠 Available MCP Tools
+
+The MCP server exposes 18 tools organized into 5 categories:
+
+### Basic Operations (7 tools)
+1. **`health_check`** - Check API health status
+2. **`get_demo_schedule`** - Retrieve demo shift schedule with sample data
+3. **`solve_schedule_sync`** - Solve shift scheduling synchronously (blocks until complete)
+4. **`solve_schedule_async`** - Start async optimization (returns job ID immediately)
+5. **`get_solve_status`** - Check async job status and get results
+6. **`analyze_weekly_hours`** - Analyze weekly work hours for constraint violations
+7. **`test_weekly_constraints`** - Test weekly hour constraints with demo data
+
+### Schedule Management (1 tool)
+8. **`get_schedule_shifts`** - Inspect completed schedules in detail
+
+### Continuous Planning (4 tools)
+9. **`swap_shifts`** - Swap employees between two shifts during optimization
+10. **`find_shift_replacement`** - Find replacement when employee becomes unavailable
+11. **`pin_shifts`** - Pin/unpin shifts to prevent changes during optimization
+12. **`reassign_shift`** - Reassign shift to specific employee or unassign
+
+### HTML Report Generation (3 tools)
+13. **`get_demo_schedule_html`** - Get demo schedule as formatted HTML report
+14. **`get_schedule_html_report`** - Get completed schedule as HTML report
+15. **`solve_schedule_sync_html`** - Solve and return HTML report in one step
+
+### PDF Report Generation (3 tools)
+16. **`get_demo_schedule_pdf`** - Get demo schedule as PDF report
+17. **`get_schedule_pdf_report`** - Get completed schedule as PDF report
+18. **`solve_schedule_sync_pdf`** - Solve and return PDF report in one step
+
+## 📋 Usage Examples
+
+### Basic Schedule Optimization
+
+```markdown
+@claude I need to create a shift schedule for my team. Can you help me optimize it?
+
+Here are my employees:
+- John: Nurse, CPR certified
+- Sarah: Nurse, full-time
+- Mike: Security guard
+- Emily: Receptionist, admin skills
+
+And I need coverage for:
+- Morning shift (8AM-4PM): Nurse required
+- Night shift (10PM-6AM): Security required
+- Reception (9AM-5PM): Admin skills required
+```
+
+### Continuous Planning Workflow
+
+```markdown
+@claude I have an active optimization job (ID: abc123) and need to make some changes:
+
+1. Pin the morning shift on Monday to keep John assigned
+2. Swap the employees between Tuesday morning and evening shifts  
+3. Find a replacement for Sarah on Wednesday (she called in sick)
+```
+
+### Report Generation
+
+```markdown
+@claude Can you generate a PDF report for the completed schedule from job ID xyz789? I need it for the manager meeting.
+```
+
+## 🔧 Tool Details
+
+### Employee and Shift Data Structure
+
+**Employee Format:**
+```json
+{
+  "id": "emp1",
+  "name": "John Doe", 
+  "skills": ["Nurse", "CPR", "Full-time"]
+}
+```
+
+**Shift Format:**
+```json
+{
+  "id": "morning_shift_mon",
+  "start_time": "2025-06-01T08:00:00",
+  "end_time": "2025-06-01T16:00:00", 
+  "required_skills": ["Nurse"],
+  "location": "Hospital Ward A",
+  "priority": 1
+}
+```
+
+### Continuous Planning Requirements
+
+All continuous planning tools require:
+- **Active job ID**: From an async solve operation (`solve_schedule_async`)
+- **Job in solving state**: The job must be actively optimizing (status: `SOLVING_SCHEDULED`)
+- **Valid shift/employee IDs**: Must reference existing entities in the problem
+
+### Report Generation Features
+
+**HTML Reports:**
+- Formatted web view with styling
+- Statistics and constraint violations
+- Interactive and printable
+- Embedded CSS for standalone viewing
+
+**PDF Reports:**
+- Professional layout optimized for printing
+- Automatic filename generation with timestamps
+- Binary content returned as downloadable file
+- Includes all schedule data and optimization scores
+
+## 🔍 Troubleshooting
+
+### Common Issues
+
+#### 1. MCP Server Not Connecting
+- **Check API Status**: Ensure the API server is running on port 8081
+- **Verify Configuration**: Double-check the Claude Desktop config file path and syntax
+- **Restart Claude**: Always restart Claude Desktop after config changes
+
+#### 2. Tool Execution Errors
+- **API Timeout**: Large datasets may require longer processing (default: 120 seconds)
+- **Invalid Job ID**: Ensure job IDs are from active async solve operations
+- **Missing Dependencies**: PDF tools require WeasyPrint dependencies
+
+#### 3. Continuous Planning Failures
+- **Job State**: Job must be in active solving state (not completed)
+- **Invalid References**: Shift/employee IDs must exist in the original problem
+- **Constraint Violations**: Some operations may fail if they violate hard constraints
+
+### Debug Mode
+
+Set environment variable for detailed logging:
+```bash
+export SHIFT_SCHEDULER_API_URL="http://localhost:8081"
+export PYTHONPATH="/path/to/natural-shift-planner/src"
+```
+
+### Checking API Health
+
+Use the health check tool to verify connectivity:
+```markdown
+@claude Can you check if the shift scheduler API is healthy?
+```
+
+## 📊 Performance Considerations
+
+- **Synchronous Operations**: Block until complete, suitable for small datasets (< 100 shifts)
+- **Asynchronous Operations**: Return immediately, better for large datasets (> 100 shifts)
+- **Continuous Planning**: Minimal overhead, changes applied in real-time during optimization
+- **Report Generation**: HTML is faster, PDF requires additional rendering time
+
+## 🔒 Security Notes
+
+- MCP server runs locally and communicates with local API only
+- No external network access required
+- All data remains on your local machine
+- Use in trusted environments only
+
+## 🆘 Getting Help
+
+If you encounter issues:
+
+1. **Check API Status**: `curl http://localhost:8081/health`
+2. **Verify MCP Config**: Ensure JSON syntax is valid
+3. **Review Logs**: Check Claude Desktop logs for MCP connection errors
+4. **Test Basic Tools**: Start with `health_check` before complex operations
+
+For additional support, refer to the main README.md and API documentation.

--- a/README.md
+++ b/README.md
@@ -147,10 +147,18 @@ GET  /api/shifts/test-weekly          # Weekly work hours constraint test (demo)
 ### Continuous Planning Endpoints (NEW!)
 
 ```http
-POST /api/shifts/swap                        # Swap employees between two shifts
-POST /api/shifts/replace                     # Find replacement for unavailable employee
-POST /api/shifts/pin                         # Pin/unpin shifts for continuous planning
-POST /api/shifts/reassign                    # Reassign shift to specific employee
+POST /api/shifts/{job_id}/swap               # Swap employees between two shifts
+POST /api/shifts/{job_id}/replace            # Find replacement for unavailable employee
+POST /api/shifts/{job_id}/pin                # Pin/unpin shifts for continuous planning
+POST /api/shifts/{job_id}/reassign           # Reassign shift to specific employee
+```
+
+### Job Management Endpoints (NEW!)
+
+```http
+GET  /api/jobs                               # List all jobs
+DELETE /api/jobs/{job_id}                    # Delete specific job
+POST /api/jobs/cleanup                       # Clean up old jobs
 ```
 
 ### Report Generation Endpoints

--- a/docs/SYSTEM_SPECIFICATION.md
+++ b/docs/SYSTEM_SPECIFICATION.md
@@ -206,7 +206,7 @@ class ShiftSchedule:
 
 ### Base URL
 ```
-http://localhost:8000
+http://localhost:8081
 ```
 
 ### Authentication
@@ -259,18 +259,23 @@ GET /api/shifts/solve/{job_id}
 Response: SolutionResponse
 ```
 
-#### 5. Shift Pinning Feature
+#### 5. Continuous Planning Features
 ```http
-POST /api/shifts/pin
-Request: {"shift_id": string, "employee_id": string}
-Response: PinningResponse
+POST /api/shifts/{job_id}/swap
+Request: {"shift1_id": string, "shift2_id": string}
+Response: ContinuousPlanningResponse
 
-POST /api/shifts/unpin  
-Request: {"shift_id": string}
-Response: PinningResponse
+POST /api/shifts/{job_id}/replace
+Request: {"shift_id": string, "unavailable_employee_id": string}
+Response: ContinuousPlanningResponse
 
-GET /api/shifts/pinning-status/{job_id}
-Response: PinningStatusResponse
+POST /api/shifts/{job_id}/pin
+Request: {"shift_ids": array, "action": "pin" | "unpin"}
+Response: ContinuousPlanningResponse
+
+POST /api/shifts/{job_id}/reassign
+Request: {"shift_id": string, "new_employee_id": string}
+Response: ContinuousPlanningResponse
 ```
 
 #### 6. Weekly Work Hours Analysis


### PR DESCRIPTION
This PR fixes all the API endpoint documentation issues identified in issue #33.

## Changes
- Fix continuous planning endpoints in README.md to include missing {job_id} parameters
- Add missing job management endpoints to README.md
- Fix port mismatch in SYSTEM_SPECIFICATION.md (8000 → 8081)
- Update SYSTEM_SPECIFICATION.md with correct continuous planning endpoints
- Create comprehensive MCP_SERVER.md with setup instructions and all 18 MCP tools
- Add missing PDF MCP tools to CLAUDE.md documentation

Fixes #33

Generated with [Claude Code](https://claude.ai/code)