### PR TITLE
fix: ShiftSchedule __str__ AttributeError during solver initialization

### DIFF
--- a/src/natural_shift_planner/core/models/schedule.py
+++ b/src/natural_shift_planner/core/models/schedule.py
@@ -61,7 +61,7 @@ class ShiftSchedule:
         self.shifts.append(shift)
 
     def __str__(self):
-        score_str = str(self.score) if self.score is not None else "None"
+        score_str = str(self.score) if hasattr(self, 'score') and self.score is not None else "None"
         return (
             f"ShiftSchedule("
             f"employees={len(self.employees)}, "


### PR DESCRIPTION
Fixes AttributeError in ShiftSchedule.__str__ method during Timefold solver initialization.

During solver initialization, the score attribute may not exist yet when __str__ is called by the Timefold solver. This change safely checks for the attribute's existence before accessing it, preventing the AttributeError that was breaking solver operations.

Fixes #58

Generated with [Claude Code](https://claude.ai/code)