### PR TITLE
Add Dependabot configuration for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,45 @@
+# Dependabot configuration for automated dependency updates
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Python dependencies
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
+    pull-request-branch-name:
+      separator: "/"
+    reviewers:
+      - "vtakaj"
+    
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    pull-request-branch-name:
+      separator: "/"
+    reviewers:
+      - "vtakaj"


### PR DESCRIPTION
## Summary
- Add Dependabot configuration to automatically manage dependency updates
- Configure for both Python dependencies and GitHub Actions
- Implement weekly update schedule with appropriate limits

## Changes
- Created `.github/dependabot.yml` with comprehensive configuration
- Set up weekly updates on Monday mornings (JST)
- Added labels for better PR organization
- Configured commit message prefixes following conventional commits

## Configuration Details

### Python Dependencies
- Package ecosystem: pip
- Update frequency: Weekly
- PR limit: 5 concurrent PRs
- Labels: `dependencies`, `python`
- Commit prefix: `chore`

### GitHub Actions
- Update frequency: Weekly  
- PR limit: 3 concurrent PRs
- Labels: `dependencies`, `github-actions`
- Commit prefix: `ci`

## Benefits
- 🔒 Automated security vulnerability detection and updates
- 📦 Keep dependencies current without manual intervention
- 🤖 Organized PRs with clear labels and commit messages
- ⏰ Predictable update schedule

Closes #61

## Test plan
- [x] Create valid dependabot.yml configuration
- [ ] Merge PR to enable Dependabot
- [ ] Monitor initial dependency update PRs

🤖 Generated with [Claude Code](https://claude.ai/code)