### PR TITLE
fix: replace unsupported version command in pulumi workflow

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -56,8 +56,7 @@ jobs:
       - name: Configure Pulumi
         uses: pulumi/actions@v5
         with:
-          command: version
-          stack-name: ${{ github.event.inputs.stack || 'dev' }}
+          command: whoami
           work-dir: ./infrastructure
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}


### PR DESCRIPTION
Fixes #87

The `pulumi/actions@v5` action does not support the `version` command in the workflow context. This PR replaces it with `whoami` command which:

- Validates Pulumi authentication and configuration
- Fails fast if there are authentication issues
- Is a supported command in pulumi/actions@v5

Generated with [Claude Code](https://claude.ai/code)