### PR TITLE
fix: add package write permissions to GitHub Actions workflow

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -28,6 +28,11 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}/shift-scheduler
 
+permissions:
+  contents: read
+  packages: write
+  pull-requests: read
+
 jobs:
   test:
     name: Run Tests


### PR DESCRIPTION
## Summary
Fixes the GitHub Container Registry (ghcr.io) push permission error by adding explicit package write permissions to the workflow.

## Problem
The workflow was failing with:
```
ERROR: failed to solve: failed to push ghcr.io/vtakaj/natural-shift-planner/shift-scheduler:main: 
denied: installation not allowed to Create organization package
```

**Failed workflow run**: https://github.com/vtakaj/natural-shift-planner/actions/runs/15659913114/job/44116134776

## Solution
Added explicit permissions to the workflow:
```yaml
permissions:
  contents: read       # Read repository content
  packages: write      # Push to ghcr.io
  pull-requests: read  # Read PR information
```

## Why This Works
- GitHub Actions needs explicit `packages: write` permission to push to ghcr.io
- This is a security best practice - workflows should declare needed permissions
- The default GITHUB_TOKEN will now have the correct scopes

## Alternative Solution (if this doesn't work)
If organization restrictions still prevent pushing, we can:
1. Create a Personal Access Token (PAT) with `write:packages` scope
2. Add it as repository secret `GHCR_TOKEN`
3. Update the login step to use `${{ secrets.GHCR_TOKEN }}`

## Testing
After merge, the workflow should:
- ✅ Build Docker images successfully
- ✅ Push to ghcr.io without permission errors
- ✅ Create multi-platform images (amd64/arm64)

## Related Issues
Fixes #91

🤖 Generated with [Claude Code](https://claude.ai/code)