### PR TITLE
Fix Pulumi virtual environment activation in workflow

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -54,9 +54,11 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
 
-      - name: Install Pulumi dependencies
+      - name: Install Pulumi dependencies and activate venv
         run: |
           uv sync --frozen
+          echo "VIRTUAL_ENV=$(pwd)/.venv" >> $GITHUB_ENV
+          echo "$(pwd)/.venv/bin" >> $GITHUB_PATH
 
       - name: Azure CLI Login
         uses: azure/login@v2


### PR DESCRIPTION
## Summary
- Activate uv virtual environment so Pulumi can access Python dependencies

## Problem
After fixing the invalid commands in PR #96, the workflow is now failing with:
```
ModuleNotFoundError: No module named 'pulumi'
It looks like the Pulumi SDK has not been installed.
```

## Solution
The `uv sync --frozen` installs dependencies in a virtual environment, but the environment variables need to be set so that Pulumi can find the installed packages.

## Test plan
- [x] Virtual environment path is added to GITHUB_PATH
- [x] VIRTUAL_ENV environment variable is set
- [x] Pulumi should now be able to import required modules

🤖 Generated with [Claude Code](https://claude.ai/code)