### PR TITLE
Fix infrastructure Python dependencies installation

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -51,12 +51,11 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v6
-
-      - name: Install Pulumi dependencies and activate venv
+      - name: Install Pulumi dependencies
         run: |
-          uv sync --frozen
+          python -m venv .venv
+          source .venv/bin/activate
+          pip install -r requirements.txt
           echo "VIRTUAL_ENV=$(pwd)/.venv" >> $GITHUB_ENV
           echo "$(pwd)/.venv/bin" >> $GITHUB_PATH
 


### PR DESCRIPTION
## Summary
- Replace uv with pip for installing Pulumi Python dependencies
- Use standard Python venv instead of uv's virtual environment

## Problem
The infrastructure workflow fails with:
```
ModuleNotFoundError: No module named 'pulumi'
```

This happens because:
1. The infrastructure directory uses `requirements.txt`, not `pyproject.toml`
2. `uv sync --frozen` expects a `pyproject.toml` file
3. The virtual environment isn't being properly activated for Pulumi

## Solution
- Use standard `python -m venv` to create virtual environment
- Use `pip install -r requirements.txt` to install dependencies
- Properly set VIRTUAL_ENV and PATH environment variables

## Test plan
- [x] Virtual environment is created with standard Python venv
- [x] Pulumi dependencies installed via pip from requirements.txt
- [x] Environment variables set so Pulumi can find modules

🤖 Generated with [Claude Code](https://claude.ai/code)