### PR TITLE
fix: use JSON creds format for Azure login action

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -62,11 +62,13 @@ jobs:
       - name: Azure CLI Login
         uses: azure/login@v2
         with:
-          auth-type: SERVICE_PRINCIPAL
-          client-id: ${{ secrets.ARM_CLIENT_ID }}
-          tenant-id: ${{ secrets.ARM_TENANT_ID }}
-          subscription-id: ${{ secrets.ARM_SUBSCRIPTION_ID }}
-          client-secret: ${{ secrets.ARM_CLIENT_SECRET }}
+          creds: |
+            {
+              "clientId": "${{ secrets.ARM_CLIENT_ID }}",
+              "clientSecret": "${{ secrets.ARM_CLIENT_SECRET }}",
+              "tenantId": "${{ secrets.ARM_TENANT_ID }}",
+              "subscriptionId": "${{ secrets.ARM_SUBSCRIPTION_ID }}"
+            }
 
       - name: Pulumi Preview (PR)
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Summary
- Updated Azure login action in infrastructure workflow to use JSON credentials format
- Removed deprecated auth-type parameter and individual credential fields
- Ensures compatibility with latest azure/login@v2 action requirements

## Changes
- Modified `.github/workflows/infrastructure.yml` to use the `creds` parameter with JSON format instead of individual credential parameters
- Maintains the same secrets but formats them as a JSON object as required by the action

## Test plan
- [ ] Verify GitHub Actions workflow runs successfully with the new format
- [ ] Confirm Azure CLI login succeeds in the infrastructure deployment pipeline
- [ ] Check that Pulumi operations can authenticate properly

🤖 Generated with [Claude Code](https://claude.ai/code)