### PR TITLE
fix: standardize Azure location format and simplify naming convention

### DIFF
--- a/infrastructure/Pulumi.dev.yaml
+++ b/infrastructure/Pulumi.dev.yaml
@@ -1,5 +1,5 @@
 config:
-  azure-native:location: Japan East
+  azure-native:location: japaneast
   shift-scheduler-infra:environment: development
   shift-scheduler-infra:instance_count: 1
   shift-scheduler-infra:sku_size: Basic

--- a/infrastructure/Pulumi.prod.yaml
+++ b/infrastructure/Pulumi.prod.yaml
@@ -1,5 +1,5 @@
 config:
-  azure-native:location: Japan East
+  azure-native:location: japaneast
   shift-scheduler-infra:environment: production
   shift-scheduler-infra:instance_count: 3
   shift-scheduler-infra:sku_size: Standard

--- a/infrastructure/Pulumi.yaml
+++ b/infrastructure/Pulumi.yaml
@@ -5,4 +5,4 @@ template:
   config:
     azure-native:location:
       description: The Azure location to deploy to
-      default: East US
+      default: japaneast

--- a/infrastructure/config/naming.py
+++ b/infrastructure/config/naming.py
@@ -35,48 +35,6 @@ ENVIRONMENT_ABBREVIATIONS = {
     "prod": "prod",
 }
 
-# Azure regions abbreviations
-REGION_ABBREVIATIONS = {
-    "East US": "eus",
-    "East US 2": "eus2",
-    "West US": "wus",
-    "West US 2": "wus2",
-    "West US 3": "wus3",
-    "Central US": "cus",
-    "North Central US": "ncus",
-    "South Central US": "scus",
-    "West Central US": "wcus",
-    "Canada Central": "cac",
-    "Canada East": "cae",
-    "Brazil South": "brs",
-    "North Europe": "ne",
-    "West Europe": "we",
-    "UK South": "uks",
-    "UK West": "ukw",
-    "France Central": "fc",
-    "France South": "fs",
-    "Germany West Central": "gwc",
-    "Germany North": "gn",
-    "Norway East": "noe",
-    "Norway West": "now",
-    "Switzerland North": "sn",
-    "Switzerland West": "sw",
-    "Southeast Asia": "sea",
-    "East Asia": "ea",
-    "Australia East": "ae",
-    "Australia Southeast": "ase",
-    "Australia Central": "ac",
-    "Australia Central 2": "ac2",
-    "Japan East": "je",
-    "Japan West": "jw",
-    "Korea Central": "kc",
-    "Korea South": "ks",
-    "India Central": "ic",
-    "India South": "is",
-    "India West": "iw",
-}
-
-
 class AzureNamingConvention:
     """Azure resource naming convention helper"""
 
@@ -103,7 +61,7 @@ class AzureNamingConvention:
             project.lower().replace("-", "").replace("_", "")[:8]
         )  # Max 8 chars for project
         self.environment = self._get_environment_abbr(environment)
-        self.location = self._get_location_abbr(location)
+        self.location = location
         self.instance = instance
 
     def _get_environment_abbr(self, environment: str | None) -> str:
@@ -115,14 +73,6 @@ class AzureNamingConvention:
         return ENVIRONMENT_ABBREVIATIONS.get(
             environment.lower(), environment.lower()[:3]
         )
-
-    def _get_location_abbr(self, location: str | None) -> str:
-        """Get location abbreviation"""
-        if not location:
-            config = pulumi.Config()
-            location = config.get("azure-native:location") or "Japan East"
-
-        return REGION_ABBREVIATIONS.get(location, location.lower().replace(" ", "")[:4])
 
     def resource_group(self, workload: str = "core") -> str:
         """


### PR DESCRIPTION
## Summary
- Standardized Azure location format from mixed case (e.g., "Japan East") to lowercase (e.g., "japaneast")
- Removed hardcoded region abbreviations mapping to simplify the naming convention
- Updated all Pulumi configuration files to use the new format

## Changes
- Modified `infrastructure/Pulumi.yaml`, `infrastructure/Pulumi.dev.yaml`, and `infrastructure/Pulumi.prod.yaml` to use lowercase location format
- Simplified `infrastructure/config/naming.py` by removing the 40+ line region abbreviations dictionary
- Location is now used directly in resource naming instead of being converted to abbreviations

## Test plan
- [ ] Verify Pulumi preview runs successfully with the new location format
- [ ] Confirm Azure resources can be created with the updated naming convention
- [ ] Check that existing resources are not affected by the naming changes

🤖 Generated with [Claude Code](https://claude.ai/code)