### PR TITLE
fix: prevent AttributeError in Shift.__str__ method during optimization

### DIFF
--- a/src/natural_shift_planner/core/models/shift.py
+++ b/src/natural_shift_planner/core/models/shift.py
@@ -57,7 +57,11 @@ class Shift:
         return self.pinned
 
     def __str__(self):
-        employee_name = self.employee.name if self.employee else "未割り当て"
+        employee_name = (
+            self.employee.name
+            if self.employee is not None and hasattr(self.employee, "name")
+            else "未割り当て"
+        )
         return (
             f"Shift(id='{self.id}', "
             f"start={self.start_time.strftime('%Y-%m-%d %H:%M')}, "


### PR DESCRIPTION
## Summary

Fixes a critical bug where Timefold Solver optimization fails with `AttributeError: object '<class Employee>' does not have attribute '__bool__'` during the solving process.

## Problem

- During optimization, Timefold Solver temporarily assigns the `Employee` class type to `shift.employee` instead of an instance or `None`
- The original condition `if self.employee` in `Shift.__str__()` triggers `__bool__` method lookup
- Since the `Employee` class doesn't define `__bool__`, this causes an `AttributeError`
- This happens when the solver tries to create string representations of moves for logging/debugging

## Solution

- Replace `if self.employee` with explicit `is not None and hasattr(self.employee, 'name')` check
- Ensures safe string representation during solver's move evaluation phase
- Maintains backward compatibility and proper functionality
- No functional change to normal operation

## Changes

- Updated `Shift.__str__` method to use more defensive checking
- Prevents solver crashes during optimization logging/debugging
- Code formatting improvements

## Test Plan

- [x] All existing tests pass
- [x] Code formatting and linting applied
- [x] No regression in normal functionality
- [x] Solver no longer crashes with AttributeError during optimization

🤖 Generated with [Claude Code](https://claude.ai/code)