### PR TITLE
fix: prevent KeyError in weekly hours analysis

### DIFF
--- a/src/natural_shift_planner/api/analysis.py
+++ b/src/natural_shift_planner/api/analysis.py
@@ -53,8 +53,14 @@ def analyze_weekly_hours(schedule: ShiftSchedule) -> dict[str, Any]:
         duration_minutes = shift.get_duration_minutes()
 
         # Aggregate by employee
-        # defaultdict will auto-create nested structure
-        if "total_minutes" not in weekly_hours_by_employee[emp_id][week_key]:
+        # Check if week_key exists first, then check for total_minutes
+        if week_key not in weekly_hours_by_employee[emp_id]:
+            weekly_hours_by_employee[emp_id][week_key] = {
+                "total_minutes": 0,
+                "shift_count": 0,
+                "shifts": [],
+            }
+        elif "total_minutes" not in weekly_hours_by_employee[emp_id][week_key]:
             weekly_hours_by_employee[emp_id][week_key] = {
                 "total_minutes": 0,
                 "shift_count": 0,


### PR DESCRIPTION
## Summary
- Fixed KeyError that occurs when analyzing weekly hours for shifts
- Added proper check for week_key existence before accessing nested fields

## Problem
The `analyze_weekly_hours` function was attempting to check for nested fields without first verifying that the parent key exists in the dictionary, causing a KeyError.

## Solution
Added a check to verify `week_key` exists in the employee's data structure before attempting to access nested fields. This ensures proper initialization of the weekly hours data structure.

## Test plan
- [x] Verified the fix prevents KeyError when processing shifts
- [x] Confirmed weekly hours analysis works correctly with various shift patterns
- [x] Tested with empty schedules and schedules with multiple weeks

🤖 Generated with [Claude Code](https://claude.ai/code)