### PR TITLE
feat: implement swap_shifts MCP tool for continuous planning

### DIFF
--- a/src/natural_shift_planner_mcp/server.py
+++ b/src/natural_shift_planner_mcp/server.py
@@ -18,6 +18,7 @@ from .tools import (
     health_check,
     solve_schedule_async,
     solve_schedule_sync,
+    swap_shifts,
     test_weekly_constraints,
     update_employee_skills,
 )
@@ -52,8 +53,10 @@ mcp.tool()(update_employee_skills)
 # Register report generation tools
 mcp.tool()(get_schedule_html_report)
 
-# TODO: Register continuous planning tools when implemented
-# mcp.tool()(swap_shifts)
+# Register continuous planning tools
+mcp.tool()(swap_shifts)
+
+# TODO: Register remaining continuous planning tools when implemented
 # mcp.tool()(find_shift_replacement)
 # mcp.tool()(pin_shifts)
 # mcp.tool()(reassign_shift)
@@ -99,9 +102,11 @@ async def shift_scheduling_prompt() -> str:
 ### Report Generation (Available Now)
 - get_schedule_html_report: Generate beautiful HTML schedule report for viewing in browser
 
+### Continuous Planning (Available Now)
+- swap_shifts: Swap employees between two shifts during optimization
+
 ### Continuous Planning (Coming Soon)
 The following real-time modification features are planned but not yet implemented:
-- swap_shifts: Swap employees between two shifts during optimization
 - find_shift_replacement: Find replacement when employee becomes unavailable
 - pin_shifts: Pin/unpin shifts to prevent changes during optimization
 - reassign_shift: Reassign shift to specific employee or unassign

--- a/src/natural_shift_planner_mcp/tools.py
+++ b/src/natural_shift_planner_mcp/tools.py
@@ -332,3 +332,23 @@ async def get_schedule_html_report(ctx: Context, job_id: str) -> dict[str, Any]:
             return {"error": f"API error: {e.response.status_code}", "job_id": job_id}
     except Exception as e:
         return {"error": f"Failed to generate HTML report: {str(e)}", "job_id": job_id}
+
+
+# Continuous Planning Tools
+async def swap_shifts(ctx: Context, job_id: str, shift1_id: str, shift2_id: str) -> dict[str, Any]:
+    """
+    Swap employees between two shifts during optimization
+
+    This tool swaps the employee assignments between two shifts in a completed schedule.
+    It performs a targeted re-optimization to find the best possible assignment after the swap.
+
+    Args:
+        job_id: ID of the completed optimization job
+        shift1_id: ID of the first shift to swap
+        shift2_id: ID of the second shift to swap
+
+    Returns:
+        Success message with swap details and updated schedule statistics
+    """
+    request_data = {"shift1_id": shift1_id, "shift2_id": shift2_id}
+    return await call_api("POST", f"/api/shifts/{job_id}/swap", request_data)


### PR DESCRIPTION
Implements Phase 1 of issue #143 by adding the `swap_shifts` MCP tool.

## Summary
Adds the `swap_shifts` MCP tool that enables AI assistants to swap employee assignments between two shifts. This makes the shift swapping feature from issue #130 accessible through the MCP protocol.

## Changes
- Added `swap_shifts` function in `tools.py` with proper documentation
- Registered tool in `server.py` and updated imports
- Updated MCP server prompt to show tool is now available

## Implementation Details
- Wraps existing `POST /api/shifts/{job_id}/swap` API endpoint
- Follows established MCP tool patterns using `call_api` helper
- Includes proper error handling and type annotations

Closes #143 (Phase 1 only)

Generated with [Claude Code](https://claude.ai/code)