### PR TITLE
feat: implement shift reassignment feature with force override support

### DIFF
--- a/src/natural_shift_planner/api/jobs.py
+++ b/src/natural_shift_planner/api/jobs.py
@@ -406,6 +406,192 @@ def update_employee_skills(job_id: str, employee_id: str, new_skills: set[str]) 
         return False
 
 
+def reassign_shift_in_job(job_id: str, shift_id: str, new_employee_id: str | None, force: bool = False) -> tuple[bool, list[str]]:
+    """Reassign a shift to a specific employee or unassign it"""
+    warnings = []
+    
+    try:
+        with job_lock:
+            if job_id not in jobs:
+                logger.error(f"Job {job_id} not found")
+                return False, [f"Job {job_id} not found"]
+
+            job = jobs[job_id]
+
+            # Only allow reassigning in completed jobs
+            if job["status"] != "SOLVING_COMPLETED":
+                logger.error(f"Job {job_id} status is {job['status']}, not completed")
+                return False, [f"Job {job_id} is not completed"]
+
+            if "solution" not in job:
+                logger.error(f"Job {job_id} has no solution")
+                return False, [f"Job {job_id} has no solution"]
+
+            # Get the current solution
+            current_solution = job["solution"]
+
+            # Find the shift to reassign
+            target_shift = None
+            for shift in current_solution.shifts:
+                if shift.id == shift_id:
+                    target_shift = shift
+                    break
+
+            if target_shift is None:
+                logger.error(f"Shift {shift_id} not found in solution")
+                return False, [f"Shift {shift_id} not found"]
+
+            # Find the new employee if specified
+            new_employee = None
+            if new_employee_id is not None:
+                for emp in current_solution.employees:
+                    if emp.id == new_employee_id:
+                        new_employee = emp
+                        break
+
+                if new_employee is None:
+                    logger.error(f"Employee {new_employee_id} not found in solution")
+                    return False, [f"Employee {new_employee_id} not found"]
+
+            # Mark job as being modified
+            jobs[job_id]["status"] = "REASSIGNING_SHIFT"
+            _sync_job_to_store(job_id)
+
+        # Perform validation
+        validation_errors = []
+        
+        if new_employee is not None:
+            # Check skill requirements
+            if not new_employee.has_required_skills(target_shift.required_skills):
+                missing_skills = target_shift.required_skills - new_employee.skills
+                error_msg = f"Employee {new_employee.name} lacks required skills: {missing_skills}"
+                if force:
+                    warnings.append(f"WARNING: {error_msg} (forced)")
+                    logger.warning(f"[Job {job_id}] {error_msg} - forced by user")
+                else:
+                    validation_errors.append(error_msg)
+
+            # Check availability
+            if new_employee.is_unavailable_on_date(target_shift.start_time):
+                error_msg = f"Employee {new_employee.name} is unavailable on {target_shift.start_time.date()}"
+                if force:
+                    warnings.append(f"WARNING: {error_msg} (forced)")
+                    logger.warning(f"[Job {job_id}] {error_msg} - forced by user")
+                else:
+                    validation_errors.append(error_msg)
+
+            # Check for shift overlap
+            for other_shift in current_solution.shifts:
+                if (other_shift.id != shift_id and 
+                    other_shift.employee == new_employee and 
+                    target_shift.overlaps_with(other_shift)):
+                    error_msg = f"Employee {new_employee.name} already has overlapping shift {other_shift.id} ({other_shift.start_time} - {other_shift.end_time})"
+                    if force:
+                        warnings.append(f"WARNING: {error_msg} (forced)")
+                        logger.warning(f"[Job {job_id}] {error_msg} - forced by user")
+                    else:
+                        validation_errors.append(error_msg)
+
+        # If validation failed and not forced, return errors
+        if validation_errors and not force:
+            error_msg = f"Reassignment validation failed: {'; '.join(validation_errors)}"
+            logger.error(f"[Job {job_id}] {error_msg}")
+            with job_lock:
+                jobs[job_id]["status"] = "SOLVING_FAILED"
+                jobs[job_id]["error"] = error_msg
+                _sync_job_to_store(job_id)
+            return False, validation_errors
+
+        # Store the old assignment for logging
+        old_employee = target_shift.employee
+        old_employee_name = old_employee.name if old_employee else "unassigned"
+        new_employee_name = new_employee.name if new_employee else "unassigned"
+
+        logger.info(
+            f"[Job {job_id}] Reassigning shift {shift_id} from {old_employee_name} to {new_employee_name}"
+        )
+
+        # Pin all other assignments to preserve them during re-optimization
+        pinned_count = 0
+        for shift in current_solution.shifts:
+            if shift.id != shift_id and shift.employee is not None and not shift.pinned:
+                # Only pin assignments without violations
+                current_emp = shift.employee
+                has_violation = False
+
+                # Check for hard constraint violations
+                if not current_emp.has_required_skills(shift.required_skills):
+                    has_violation = True
+                elif current_emp.is_unavailable_on_date(shift.start_time):
+                    has_violation = True
+
+                # Only pin valid assignments
+                if not has_violation:
+                    shift.pin()
+                    pinned_count += 1
+
+        logger.info(f"[Job {job_id}] Pinned {pinned_count} other assignments")
+
+        # Directly set the new assignment
+        target_shift.employee = new_employee
+
+        # Use solver to validate and optimize around the new assignment
+        solver = solver_factory.build_solver()
+
+        logger.info(f"[Job {job_id}] Running solver to validate reassignment...")
+        updated_solution = solver.solve(current_solution)
+
+        # Unpin shifts for future modifications
+        for shift in updated_solution.shifts:
+            if shift.pinned:
+                shift.pinned = False
+
+        # Update the job with new solution
+        with job_lock:
+            jobs[job_id]["status"] = "SOLVING_COMPLETED"
+            jobs[job_id]["solution"] = updated_solution
+            jobs[job_id]["updated_at"] = datetime.now()
+            jobs[job_id]["final_score"] = str(updated_solution.score)
+
+            # Track the reassignment
+            if "shift_reassignments" not in jobs[job_id]:
+                jobs[job_id]["shift_reassignments"] = []
+            jobs[job_id]["shift_reassignments"].append(
+                {
+                    "shift_id": shift_id,
+                    "old_employee_id": old_employee.id if old_employee else None,
+                    "old_employee_name": old_employee_name,
+                    "new_employee_id": new_employee.id if new_employee else None,
+                    "new_employee_name": new_employee_name,
+                    "forced": force,
+                    "warnings": warnings,
+                    "timestamp": datetime.now(),
+                }
+            )
+            _sync_job_to_store(job_id)
+
+        total_assigned = sum(
+            1 for s in updated_solution.shifts if s.employee is not None
+        )
+
+        logger.info(
+            f"[Job {job_id}] Shift reassignment completed successfully. "
+            f"Score: {updated_solution.score}, "
+            f"Total assigned shifts: {total_assigned}/{len(updated_solution.shifts)}"
+        )
+
+        return True, warnings
+
+    except Exception as e:
+        logger.error(f"[Job {job_id}] Failed to reassign shift: {str(e)}")
+        with job_lock:
+            if job_id in jobs:
+                jobs[job_id]["status"] = "SOLVING_FAILED"
+                jobs[job_id]["error"] = f"Shift reassignment failed: {str(e)}"
+                _sync_job_to_store(job_id)
+        return False, [f"Internal error: {str(e)}"]
+
+
 def swap_shifts_in_job(job_id: str, shift1_id: str, shift2_id: str) -> bool:
     """Swap employee assignments between two shifts in a completed job"""
     try:

--- a/src/natural_shift_planner/api/routes.py
+++ b/src/natural_shift_planner/api/routes.py
@@ -17,12 +17,15 @@ from .jobs import (
     add_employee_to_completed_job,
     job_lock,
     jobs,
+    reassign_shift_in_job,
     solve_problem_async,
     swap_shifts_in_job,
     update_employee_skills,
 )
 from .schemas import (
     EmployeeRequest,
+    ReassignShiftRequest,
+    ReassignShiftResponse,
     ShiftScheduleRequest,
     SolutionResponse,
     SolveResponse,
@@ -463,6 +466,57 @@ async def swap_shifts(job_id: str, request: SwapShiftsRequest):
                 error_msg = jobs[job_id].get("error", "Unknown error occurred")
             else:
                 error_msg = "Job not found"
+
+        raise HTTPException(status_code=400, detail=error_msg)
+
+
+@router.post("/api/shifts/{job_id}/reassign", response_model=ReassignShiftResponse)
+async def reassign_shift(job_id: str, request: ReassignShiftRequest):
+    """Reassign a shift to a specific employee or unassign it"""
+    # Perform the reassignment
+    success, warnings_or_errors = reassign_shift_in_job(
+        job_id, request.shift_id, request.employee_id, request.force
+    )
+
+    if success:
+        # Get updated job info
+        with job_lock:
+            job = jobs[job_id]
+            solution = job["solution"]
+
+        # Find the reassigned shift to get current assignment
+        current_employee = None
+        current_employee_name = None
+        for shift in solution.shifts:
+            if shift.id == request.shift_id:
+                current_employee = shift.employee
+                current_employee_name = (
+                    shift.employee.name if shift.employee else None
+                )
+                break
+
+        return ReassignShiftResponse(
+            job_id=job_id,
+            shift_id=request.shift_id,
+            employee_id=current_employee.id if current_employee else None,
+            employee_name=current_employee_name,
+            status="SUCCESS",
+            message=f"Successfully reassigned shift {request.shift_id} to {current_employee_name or 'unassigned'}",
+            warnings=warnings_or_errors,  # These are warnings when success=True
+            final_score=str(solution.score),
+            html_report_url=f"/api/shifts/solve/{job_id}/html",
+        )
+    else:
+        # Get error details from job
+        with job_lock:
+            if job_id in jobs:
+                error_msg = jobs[job_id].get("error", "Unknown error occurred")
+            else:
+                error_msg = "Job not found"
+
+        # Use the specific errors returned from the function
+        if warnings_or_errors:
+            error_msg = "; ".join(warnings_or_errors)
 
         raise HTTPException(status_code=400, detail=error_msg)
 

--- a/src/natural_shift_planner/api/schemas.py
+++ b/src/natural_shift_planner/api/schemas.py
@@ -60,6 +60,24 @@ class SwapShiftsResponse(BaseModel):
     html_report_url: str | None = None
 
 
+class ReassignShiftRequest(BaseModel):
+    shift_id: str = Field(description="ID of the shift to reassign")
+    employee_id: str | None = Field(description="ID of the employee to assign (null to unassign)")
+    force: bool = Field(default=False, description="Override soft constraint violations")
+
+
+class ReassignShiftResponse(BaseModel):
+    job_id: str
+    shift_id: str
+    employee_id: str | None
+    employee_name: str | None
+    status: str
+    message: str
+    warnings: list[str] = Field(default_factory=list)
+    final_score: str | None = None
+    html_report_url: str | None = None
+
+
 class SolutionResponse(BaseModel):
     job_id: str
     status: str

--- a/src/natural_shift_planner_mcp/server.py
+++ b/src/natural_shift_planner_mcp/server.py
@@ -16,6 +16,7 @@ from .tools import (
     get_schedule_shifts,
     get_solve_status,
     health_check,
+    reassign_shift,
     solve_schedule_async,
     solve_schedule_sync,
     swap_shifts,
@@ -55,11 +56,11 @@ mcp.tool()(get_schedule_html_report)
 
 # Register continuous planning tools
 mcp.tool()(swap_shifts)
+mcp.tool()(reassign_shift)
 
 # TODO: Register remaining continuous planning tools when implemented
 # mcp.tool()(find_shift_replacement)
 # mcp.tool()(pin_shifts)
-# mcp.tool()(reassign_shift)
 
 # TODO: Register additional employee management tools when implemented
 # mcp.tool()(add_employees_batch_to_job)
@@ -104,12 +105,12 @@ async def shift_scheduling_prompt() -> str:
 
 ### Continuous Planning (Available Now)
 - swap_shifts: Swap employees between two shifts during optimization
+- reassign_shift: Reassign shift to specific employee or unassign (with validation and force override)
 
 ### Continuous Planning (Coming Soon)
 The following real-time modification features are planned but not yet implemented:
 - find_shift_replacement: Find replacement when employee becomes unavailable
 - pin_shifts: Pin/unpin shifts to prevent changes during optimization
-- reassign_shift: Reassign shift to specific employee or unassign
 
 ### Additional Employee Management (Coming Soon)
 The following additional employee management features are planned but not yet implemented:

--- a/src/natural_shift_planner_mcp/tools.py
+++ b/src/natural_shift_planner_mcp/tools.py
@@ -352,3 +352,30 @@ async def swap_shifts(ctx: Context, job_id: str, shift1_id: str, shift2_id: str)
     """
     request_data = {"shift1_id": shift1_id, "shift2_id": shift2_id}
     return await call_api("POST", f"/api/shifts/{job_id}/swap", request_data)
+
+
+async def reassign_shift(
+    ctx: Context, job_id: str, shift_id: str, employee_id: str | None = None, force: bool = False
+) -> dict[str, Any]:
+    """
+    Reassign a shift to a specific employee or unassign it
+
+    This tool allows managers to manually override the optimizer's decisions by reassigning
+    a shift to a specific employee or unassigning it entirely. It validates skill requirements
+    and constraints but can be forced to override soft constraint violations.
+
+    Args:
+        job_id: ID of the completed optimization job
+        shift_id: ID of the shift to reassign
+        employee_id: ID of the employee to assign (null/None to unassign)
+        force: Whether to override soft constraint violations (default: False)
+
+    Returns:
+        Success message with reassignment details, warnings, and updated schedule statistics
+    """
+    request_data = {
+        "shift_id": shift_id,
+        "employee_id": employee_id,
+        "force": force,
+    }
+    return await call_api("POST", f"/api/shifts/{job_id}/reassign", request_data)


### PR DESCRIPTION
Add capability to manually reassign shifts to specific employees or unassign them entirely.
This gives managers direct control over assignments when needed, overriding optimizer decisions.

Features:
- POST /api/shifts/{job_id}/reassign endpoint with comprehensive validation
- Skill requirement checking with force override option
- Availability and overlap constraint validation
- Support for unassigning shifts (employee_id = null)
- Warning system for soft constraint violations
- Timefold integration with pinned assignments for minimal disruption
- MCP tool integration for AI assistant access
- Detailed logging and tracking of all reassignments

Implements issue #132

Generated with [Claude Code](https://claude.ai/code)