### PR TITLE
feat: remove workload from resource group names

### DIFF
--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -18,9 +18,7 @@ def main():
 
     # Create resource group using Microsoft CAF naming convention
     rg_module = ResourceGroupModule(
-        workload="core",
         additional_tags={
-            "Workload": "core-infrastructure",
             "Purpose": "Main infrastructure components",
         },
     )

--- a/infrastructure/config/naming.py
+++ b/infrastructure/config/naming.py
@@ -80,14 +80,13 @@ class AzureNamingConvention:
             environment.lower(), environment.lower()[:3]
         )
 
-    def resource_group(self, workload: str = "core") -> str:
+    def resource_group(self) -> str:
         """
         Generate resource group name
-        Format: rg-{project}-{workload}-{env}-{instance}
-        Example: rg-nss-core-dev-001
+        Format: rg-{project}-{env}-{instance}
+        Example: rg-nss-dev-001
         """
-        workload_abbr = workload.lower()[:8]
-        return f"rg-{self.project}-{workload_abbr}-{self.environment}-{self.instance}"
+        return f"rg-{self.project}-{self.environment}-{self.instance}"
 
     def storage_account(self, purpose: str = "data") -> str:
         """

--- a/infrastructure/modules/resource_group.py
+++ b/infrastructure/modules/resource_group.py
@@ -14,7 +14,6 @@ class ResourceGroupModule:
 
     def __init__(
         self,
-        workload: str = "core",
         location: str = None,
         additional_tags: dict[str, Any] = None,
     ):
@@ -22,12 +21,11 @@ class ResourceGroupModule:
         Initialize Resource Group module
 
         Args:
-            workload: Workload name (e.g., 'core', 'data', 'web')
             location: Azure location
             additional_tags: Additional resource tags
         """
         self.naming = get_naming_convention()
-        self.name = self.naming.resource_group(workload)
+        self.name = self.naming.resource_group()
         self.location = location or self.naming.location
         self.tags = self.naming.get_resource_tags(additional_tags)
 


### PR DESCRIPTION
Remove workload parameter from Azure resource group naming convention

Changes:
- Remove workload parameter from resource_group() method in naming.py
- Update ResourceGroupModule to not require workload parameter
- Remove workload="core" from main infrastructure deployment
- Resource group format changed from rg-{project}-{workload}-{env}-{instance} to rg-{project}-{env}-{instance}

Fixes #150

Generated with [Claude Code](https://claude.ai/code)