### PR TITLE
fix: add explicit dependency to ManagementPolicy resource

### DIFF
--- a/infrastructure/modules/storage.py
+++ b/infrastructure/modules/storage.py
@@ -126,6 +126,7 @@ class StorageModule:
                     ),
                 ]
             ),
+            opts=pulumi.ResourceOptions(depends_on=[self.storage_account])
         )
 
     def create_sas_token(


### PR DESCRIPTION
### Summary

Fixes Pulumi deployment failure where ManagementPolicy resource tries to reference storage account before it's fully provisioned.

###  Changes
- Added explicit dependency `opts=pulumi.ResourceOptions(depends_on=[self.storage_account])` to ManagementPolicy resource
- Ensures proper resource ordering during deployment

###  Testing
- Code change is straightforward dependency fix
- Can be tested with `pulumi up` command

Resolves #152

Generated with [Claude Code](https://claude.ai/code)