### PR TITLE
fix: remove lifecycle policy from Azure storage infrastructure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,7 +222,6 @@ export AZURE_STORAGE_CONTAINER_NAME="job-data"  # Optional, defaults to "job-dat
 ```
 
 #### Azure Storage Features
-- **Automatic lifecycle management**: Job data deleted after 30 days, logs archived and cleaned up
 - **SAS token support**: Secure access with time-limited tokens
 - **High availability**: Azure-managed redundancy and backup
 - **Managed identity support**: Secure authentication without connection strings

--- a/infrastructure/modules/storage.py
+++ b/infrastructure/modules/storage.py
@@ -70,63 +70,6 @@ class StorageModule:
             public_access=azure_native.storage.PublicAccess.NONE,
         )
 
-        # Create lifecycle management policy for automatic cleanup
-        self.lifecycle_policy = azure_native.storage.ManagementPolicy(
-            resource_name=f"{self.name}-lifecycle",
-            account_name=self.storage_account.name,
-            resource_group_name=resource_group_name,
-            policy=azure_native.storage.ManagementPolicySchemaArgs(
-                rules=[
-                    azure_native.storage.ManagementPolicyRuleArgs(
-                        name="DeleteOldJobData",
-                        enabled=True,
-                        type="Lifecycle",
-                        definition=azure_native.storage.ManagementPolicyDefinitionArgs(
-                            actions=azure_native.storage.ManagementPolicyActionArgs(
-                                base_blob=azure_native.storage.ManagementPolicyBaseBlobArgs(
-                                    delete=azure_native.storage.DateAfterModificationArgs(
-                                        days_after_modification_greater_than=30
-                                    )
-                                ),
-                                snapshot=azure_native.storage.ManagementPolicySnapShotArgs(
-                                    delete=azure_native.storage.DateAfterCreationArgs(
-                                        days_after_creation_greater_than=7
-                                    )
-                                ),
-                            ),
-                            filters=azure_native.storage.ManagementPolicyFilterArgs(
-                                blob_types=["blockBlob"],
-                                prefix_match=["job-data/"],
-                            ),
-                        ),
-                    ),
-                    azure_native.storage.ManagementPolicyRuleArgs(
-                        name="ArchiveOldLogs",
-                        enabled=True,
-                        type="Lifecycle",
-                        definition=azure_native.storage.ManagementPolicyDefinitionArgs(
-                            actions=azure_native.storage.ManagementPolicyActionArgs(
-                                base_blob=azure_native.storage.ManagementPolicyBaseBlobArgs(
-                                    tier_to_cool=azure_native.storage.DateAfterModificationArgs(
-                                        days_after_modification_greater_than=7
-                                    ),
-                                    tier_to_archive=azure_native.storage.DateAfterModificationArgs(
-                                        days_after_modification_greater_than=30
-                                    ),
-                                    delete=azure_native.storage.DateAfterModificationArgs(
-                                        days_after_modification_greater_than=90
-                                    ),
-                                ),
-                            ),
-                            filters=azure_native.storage.ManagementPolicyFilterArgs(
-                                blob_types=["blockBlob"],
-                                prefix_match=["logs/"],
-                            ),
-                        ),
-                    ),
-                ]
-            ),
-        )
 
     def create_sas_token(
         self, container_name: str = "job-data", permissions: str = "rwd", hours: int = 24

--- a/scripts/test_azure_storage.py
+++ b/scripts/test_azure_storage.py
@@ -173,16 +173,6 @@ def test_upload_download():
         return False
 
 
-def test_lifecycle_policies():
-    """Test that lifecycle policies are properly configured"""
-    print("\n=== Testing Lifecycle Policies ===")
-    print("ℹ️  Lifecycle policies are configured in Pulumi infrastructure")
-    print("   - Job data: Deleted after 30 days")
-    print("   - Logs: Cool after 7 days, Archive after 30 days, Delete after 90 days")
-    print("✅ Lifecycle policies configured (verify in Azure Portal)")
-    return True
-
-
 def main():
     """Main test function"""
     print("🧪 Azure Storage Integration Test")
@@ -204,7 +194,6 @@ def main():
     success &= test_configuration()
     success &= test_azure_connection()
     success &= test_upload_download()
-    success &= test_lifecycle_policies()
     
     print("\n" + "=" * 50)
     if success:


### PR DESCRIPTION
### Summary

Removes the ManagementPolicy resource that was causing Pulumi deployment failures due to dependency ordering issues.

### Changes
- Remove lifecycle policy code from storage.py
- Remove lifecycle policy test from test_azure_storage.py
- Update CLAUDE.md documentation

### Testing
- Run `pulumi up` to verify deployment succeeds
- Storage accounts and containers remain fully functional

Resolves #152

Generated with [Claude Code](https://claude.ai/code)