### PR TITLE
feat: replace Husky with pre-commit to eliminate Node.js dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,68 @@
+repos:
+  # Python formatting and linting
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.9
+    hooks:
+      # Format Python code
+      - id: ruff-format
+        name: Format Python code with ruff
+      # Lint and fix Python code
+      - id: ruff
+        name: Lint Python code with ruff
+        args: [--fix, --exit-non-zero-on-fix]
+
+  # Python type checking
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.11.2
+    hooks:
+      - id: mypy
+        name: Type check with mypy
+        # Allow mypy to fail without blocking commit (warnings only)
+        verbose: true
+        always_run: false
+        files: ^src/
+
+  # Conventional commit message validation
+  - repo: https://github.com/commitizen-tools/commitizen
+    rev: v3.29.1
+    hooks:
+      - id: commitizen
+        name: Validate conventional commit message
+        stages: [commit-msg]
+
+  # General file checks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      # Check for files that would conflict in case-insensitive filesystems
+      - id: check-case-conflict
+      # Check for merge conflict markers
+      - id: check-merge-conflict
+      # Check YAML syntax
+      - id: check-yaml
+        exclude: ^(.*\.sls|.*\.yaml\.j2)$
+      # Check JSON syntax
+      - id: check-json
+      # Check TOML syntax
+      - id: check-toml
+      # Ensure files end with newline
+      - id: end-of-file-fixer
+        exclude: ^.*\.ipynb$
+      # Remove trailing whitespace
+      - id: trailing-whitespace
+        exclude: ^.*\.ipynb$
+
+  # Python tests (pre-push only)
+  - repo: local
+    hooks:
+      - id: pytest
+        name: Run Python tests
+        entry: bash -c 'PYTHONPATH=src uv run pytest tests/ -v'
+        language: system
+        stages: [pre-push]
+        pass_filenames: false
+        always_run: true
+
+# Global configuration
+default_stages: [pre-commit]
+fail_fast: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This is a Shift Scheduler API built with FastAPI and Timefold Solver (AI optimiz
 
 ### Development Setup
 ```bash
-# Complete setup - installs all Python dependencies including FastMCP and Bun dependencies (run this first!)
+# Complete setup - installs all Python dependencies including FastMCP and pre-commit hooks (run this first!)
 make setup
 
 # Initialize Pulumi for infrastructure (if working with infrastructure)
@@ -60,6 +60,21 @@ make format
 
 # Run linters (ruff, mypy)
 make lint
+```
+
+### Git Hooks (pre-commit)
+```bash
+# Install pre-commit hooks (automatically runs during make setup)
+make hooks-install
+
+# Test all pre-commit hooks manually
+make hooks-test
+
+# Run pre-commit hooks on all files
+uv run pre-commit run --all-files
+
+# Skip pre-commit hooks for emergency commits
+git commit --no-verify -m "emergency: fix critical issue"
 ```
 
 ### Troubleshooting
@@ -183,7 +198,7 @@ The solver optimizes using HardMediumSoftScore:
 - Python 3.11+ required (3.13+ not supported by Timefold)
 - Java 17 required (for Timefold Solver)
 - Uses `uv` for Python dependency management
-- Uses `bun` for Node.js dependency management (Husky, commitlint)
+- Uses `pre-commit` for git hooks and code quality
 - FastAPI for web framework
 - Timefold Solver for constraint optimization
 
@@ -197,7 +212,7 @@ uv run pytest test_models.py::test_name -v
 1. If `uv sync` fails, delete `uv.lock` and run `make setup`
 2. Java environment must be properly configured (JAVA_HOME)
 3. Port 8081 must be available for the server
-4. If `bun install` fails, ensure bun is installed: `curl -fsSL https://bun.sh/install | bash`
+4. If pre-commit hooks fail, run `make hooks-install` to reinstall them
 
 ### API Testing
 The `api-test.http` file contains REST Client requests for testing endpoints. Use with VS Code REST Client extension or similar tools.

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 help:
 	@echo "🚀 Shift Scheduler Dev Container Commands:"
 	@echo ""
-	@echo "  setup        - Complete setup (Python, Node.js, MCP) - run this first!"
+	@echo "  setup        - Complete setup (Python, pre-commit, MCP) - run this first!"
 	@echo "  run          - Start FastAPI server only"
 	@echo "  run-mcp      - Start both API and MCP servers together"
 	@echo "  test         - Run tests"
@@ -13,8 +13,8 @@ help:
 	@echo "  lint         - Check code"
 	@echo "  clean        - Clear cache"
 	@echo ""
-	@echo "  Git Hooks (Husky):"
-	@echo "  hooks-install - Install Husky git hooks"
+	@echo "  Git Hooks (pre-commit):"
+	@echo "  hooks-install - Install pre-commit git hooks"
 	@echo "  hooks-test    - Test git hooks manually"
 	@echo ""
 	@echo "  Additional Commands:"
@@ -29,10 +29,10 @@ help:
 setup:
 	@echo "🔧 Setting up development environment..."
 	@rm -f uv.lock
-	@echo "📦 Installing Python dependencies (including FastMCP)..."
+	@echo "📦 Installing Python dependencies (including FastMCP and pre-commit)..."
 	uv sync --no-install-project
-	@echo "📦 Installing Node.js dependencies with Bun (including Husky)..."
-	bun install
+	@echo "🪝 Installing pre-commit git hooks..."
+	uv run pre-commit install --hook-type pre-commit --hook-type commit-msg --hook-type pre-push
 	@echo "✅ Setup complete!"
 
 # Install dependencies
@@ -159,19 +159,18 @@ pulumi-setup:
 	@echo "  4. pulumi config set azure-native:location 'East US'"
 	@echo "  5. pulumi up  (to deploy infrastructure)"
 
-# Husky Git Hooks
+# Pre-commit Git Hooks
 hooks-install:
-	@echo "🪝 Installing Husky git hooks with Bun..."
-	@bun install
-	@bunx husky install
+	@echo "🪝 Installing pre-commit git hooks..."
+	uv run pre-commit install --hook-type pre-commit --hook-type commit-msg --hook-type pre-push
 	@echo "✅ Git hooks installed successfully!"
 
 hooks-test:
 	@echo "🧪 Testing git hooks..."
-	@echo "📝 Testing pre-commit hook..."
-	@bash .husky/pre-commit || echo "Pre-commit hook test completed"
-	@echo "🔍 Testing commit-msg hook..."
-	@echo "feat: test commit message" | bunx commitlint || echo "Commit message validation test completed"
+	@echo "📝 Testing pre-commit hooks..."
+	uv run pre-commit run --all-files || echo "Pre-commit hooks test completed"
+	@echo "🔍 Testing commit message validation..."
+	@echo "feat: test commit message" | uv run cz check --message || echo "Commit message validation test completed"
 	@echo "✅ Hook tests completed!"
 
 # Docker commands

--- a/package.json
+++ b/package.json
@@ -4,18 +4,12 @@
   "description": "Employee shift scheduling using Timefold Solver with MCP integration",
   "type": "module",
   "scripts": {
-    "prepare": "bunx husky install",
     "lint": "uv run ruff check .",
     "lint:fix": "uv run ruff check . --fix",
     "format": "uv run ruff format .",
     "type-check": "uv run mypy .",
     "test": "uv run pytest -v",
     "test:short": "uv run pytest -v --tb=short"
-  },
-  "devDependencies": {
-    "husky": "^8.0.3",
-    "@commitlint/cli": "^17.8.1",
-    "@commitlint/config-conventional": "^17.8.1"
   },
   "repository": {
     "type": "git",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,8 @@ dev = [
     "pytest-asyncio>=0.21.0",
     "ruff>=0.1.0",
     "mypy>=1.5.0",
+    "pre-commit>=3.5.0",
+    "commitizen>=3.29.0",
 ]
 
 # Console scripts for uvx support
@@ -75,6 +77,8 @@ dev-dependencies = [
     "pytest-asyncio>=0.21.0", 
     "ruff>=0.1.0",
     "mypy>=1.5.0",
+    "pre-commit>=3.5.0",
+    "commitizen>=3.29.0",
 ]
 
 [tool.mypy]
@@ -119,3 +123,9 @@ ignore = ["E501"]  # line too long (handled by formatter)
 
 [tool.ruff.lint.isort]
 known-first-party = ["natural_shift_planner"]
+
+[tool.commitizen]
+name = "cz_conventional_commits"
+tag_format = "v$version"
+version_provider = "pep621"
+update_changelog_on_bump = false


### PR DESCRIPTION
Replaces Husky with pre-commit to eliminate Node.js dependency in dev container.

## Changes
- Remove Husky, @commitlint/cli, @commitlint/config-conventional from package.json
- Add pre-commit and commitizen to pyproject.toml dev dependencies
- Create .pre-commit-config.yaml with equivalent hook functionality
- Update Makefile to use pre-commit instead of bunx/husky commands
- Update CLAUDE.md documentation to reflect pre-commit usage
- Remove .husky/ directory and .commitlintrc.json

## Benefits
- Eliminates Node.js/bun dependency in dev container
- Maintains all existing git hook functionality
- Uses Python-based tools that integrate better with the project

Fixes #157

Generated with [Claude Code](https://claude.ai/code)