### PR TITLE
feat: separate Terraform backend by environment

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -70,10 +70,20 @@ jobs:
       - name: Terraform Init (Dev Backend)
         id: init
         run: terraform init -backend-config=backends/dev.backend.hcl -reconfigure
+        env:
+          ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+          ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+          ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
 
       - name: Terraform Validate
         id: validate
         run: terraform validate
+        env:
+          ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+          ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+          ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
 
       - name: Terraform Plan (PR - Dev)
         id: plan-pr

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -67,9 +67,9 @@ jobs:
         run: terraform fmt -check
         continue-on-error: true
 
-      - name: Terraform Init
+      - name: Terraform Init (Dev Backend)
         id: init
-        run: terraform init
+        run: terraform init -backend-config=backends/dev.backend.hcl -reconfigure
 
       - name: Terraform Validate
         id: validate
@@ -164,7 +164,9 @@ jobs:
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'plan'
         run: |
           ENV_FILE="environments/${{ github.event.inputs.environment }}.tfvars"
+          BACKEND_FILE="backends/${{ github.event.inputs.environment }}.backend.hcl"
           echo "📋 Planning infrastructure for ${{ github.event.inputs.environment }} environment..."
+          terraform init -backend-config="$BACKEND_FILE" -reconfigure
           terraform plan \
             -var-file="$ENV_FILE" \
             -no-color
@@ -177,6 +179,7 @@ jobs:
       - name: Terraform Apply (Main Branch - Dev)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
+          terraform init -backend-config=backends/dev.backend.hcl -reconfigure
           terraform apply \
             -var-file="environments/dev.tfvars" \
             -auto-approve
@@ -189,6 +192,8 @@ jobs:
       - name: Terraform Apply (Manual)
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'apply'
         run: |
+          BACKEND_FILE="backends/${{ github.event.inputs.environment }}.backend.hcl"
+          terraform init -backend-config="$BACKEND_FILE" -reconfigure
           terraform apply \
             -var-file="environments/${{ github.event.inputs.environment }}.tfvars" \
             -auto-approve
@@ -201,6 +206,8 @@ jobs:
       - name: Terraform Destroy (Manual)
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'destroy'
         run: |
+          BACKEND_FILE="backends/${{ github.event.inputs.environment }}.backend.hcl"
+          terraform init -backend-config="$BACKEND_FILE" -reconfigure
           terraform destroy \
             -var-file="environments/${{ github.event.inputs.environment }}.tfvars" \
             -auto-approve

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -42,7 +42,7 @@ jobs:
           PYTHONPATH=src uv run pytest tests/ -v --cov=src/natural_shift_planner --cov-report=xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           file: ./coverage.xml
           fail_ci_if_error: false

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -106,4 +106,22 @@ The infrastructure exports these key outputs:
 
 ## Backend Configuration
 
-For team usage, configure remote state storage by uncommenting the backend configuration in `versions.tf` and setting up an Azure Storage Account for Terraform state.
+The project uses environment-specific backend configurations for Terraform state storage:
+
+### Setup
+1. Run `./setup-remote-state.sh` to create the Azure Storage Account
+2. Use environment-specific backend files during initialization:
+
+```bash
+# Development environment
+terraform init -backend-config=backends/dev.backend.hcl
+
+# Production environment
+terraform init -backend-config=backends/prod.backend.hcl
+```
+
+### State File Locations
+- Development: `dev/shift-scheduler.tfstate`
+- Production: `prod/shift-scheduler.tfstate`
+
+This ensures complete isolation between environments.

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,6 +1,6 @@
-# Terraform Infrastructure for Shift Scheduler
+# Terraform Infrastructure for ShiftAgent
 
-This directory contains the Terraform infrastructure code for the Shift Scheduler application.
+This directory contains the Terraform infrastructure code for the ShiftAgent application.
 
 ## Architecture
 

--- a/infrastructure/backends/dev.backend.hcl
+++ b/infrastructure/backends/dev.backend.hcl
@@ -1,5 +1,5 @@
 # Development environment backend configuration
-resource_group_name  = "rg-nss-tfstate-001"
-storage_account_name = "stnsstfstate001"
+resource_group_name  = "rg-shiftagent-tfstate-001"
+storage_account_name = "stshiftagent001"
 container_name       = "tfstate"
 key                  = "dev/shift-scheduler.tfstate"

--- a/infrastructure/backends/dev.backend.hcl
+++ b/infrastructure/backends/dev.backend.hcl
@@ -1,0 +1,5 @@
+# Development environment backend configuration
+resource_group_name  = "rg-nss-tfstate-001"
+storage_account_name = "stnsstfstate001"
+container_name       = "tfstate"
+key                  = "dev/shift-scheduler.tfstate"

--- a/infrastructure/backends/prod.backend.hcl
+++ b/infrastructure/backends/prod.backend.hcl
@@ -1,5 +1,5 @@
 # Production environment backend configuration
-resource_group_name  = "rg-nss-tfstate-001"
-storage_account_name = "stnsstfstate001"
+resource_group_name  = "rg-shiftagent-tfstate-001"
+storage_account_name = "stshiftagent001"
 container_name       = "tfstate"
 key                  = "prod/shift-scheduler.tfstate"

--- a/infrastructure/backends/prod.backend.hcl
+++ b/infrastructure/backends/prod.backend.hcl
@@ -1,0 +1,5 @@
+# Production environment backend configuration
+resource_group_name  = "rg-nss-tfstate-001"
+storage_account_name = "stnsstfstate001"
+container_name       = "tfstate"
+key                  = "prod/shift-scheduler.tfstate"

--- a/infrastructure/scripts/deploy-dev.sh
+++ b/infrastructure/scripts/deploy-dev.sh
@@ -23,13 +23,9 @@ fi
 SUBSCRIPTION=$(az account show --query name -o tsv)
 echo "📋 Using Azure subscription: $SUBSCRIPTION"
 
-# Initialize Terraform if needed
-if [ ! -d ".terraform" ]; then
-    echo "🔧 Initializing Terraform..."
-    terraform init
-else
-    echo "🔧 Terraform already initialized"
-fi
+# Initialize Terraform with development backend
+echo "🔧 Initializing Terraform with development backend..."
+terraform init -backend-config=backends/dev.backend.hcl -reconfigure
 
 # Validate configuration
 echo "✅ Validating Terraform configuration..."

--- a/infrastructure/scripts/deploy-prod.sh
+++ b/infrastructure/scripts/deploy-prod.sh
@@ -31,13 +31,9 @@ if [ "$confirm" != "yes" ]; then
     exit 1
 fi
 
-# Initialize Terraform if needed
-if [ ! -d ".terraform" ]; then
-    echo "🔧 Initializing Terraform..."
-    terraform init
-else
-    echo "🔧 Terraform already initialized"
-fi
+# Initialize Terraform with production backend
+echo "🔧 Initializing Terraform with production backend..."
+terraform init -backend-config=backends/prod.backend.hcl -reconfigure
 
 # Validate configuration
 echo "✅ Validating Terraform configuration..."

--- a/infrastructure/setup-remote-state.sh
+++ b/infrastructure/setup-remote-state.sh
@@ -6,8 +6,8 @@ set -e
 echo "🏗️  Setting up Azure remote state storage for Terraform..."
 
 # Configuration
-RESOURCE_GROUP="rg-nss-tfstate-001"
-STORAGE_ACCOUNT="stnsstfstate001"
+RESOURCE_GROUP="rg-shiftagent-tfstate-001"
+STORAGE_ACCOUNT="stshiftagent001"
 CONTAINER_NAME="tfstate"
 LOCATION="Japan East"
 
@@ -32,7 +32,7 @@ echo "🏗️  Creating resource group..."
 az group create \
     --name "$RESOURCE_GROUP" \
     --location "$LOCATION" \
-    --tags purpose="terraform-state" project="nss" managed_by="terraform"
+    --tags purpose="terraform-state" project="shiftagent" managed_by="terraform"
 
 echo "✅ Resource group created"
 
@@ -48,7 +48,7 @@ az storage account create \
     --https-only true \
     --min-tls-version TLS1_2 \
     --allow-blob-public-access false \
-    --tags purpose="terraform-state" project="nss" managed_by="terraform"
+    --tags purpose="terraform-state" project="shiftagent" managed_by="terraform"
 
 echo "✅ Storage account created"
 

--- a/infrastructure/versions.tf
+++ b/infrastructure/versions.tf
@@ -3,10 +3,8 @@
 
 terraform {
   # Backend configuration for remote state storage in Azure
-  backend "azurerm" {
-    resource_group_name  = "rg-nss-tfstate-001"
-    storage_account_name = "stnsstfstate001"
-    container_name       = "tfstate"
-    key                  = "shift-scheduler.tfstate"
-  }
+  # Use environment-specific backend files:
+  # - Development: terraform init -backend-config=backends/dev.backend.hcl
+  # - Production:  terraform init -backend-config=backends/prod.backend.hcl
+  backend "azurerm" {}
 }


### PR DESCRIPTION
## Summary
- Add environment-specific backend configuration files for Terraform state isolation
- Update deployment scripts to use separate tfstate files for dev and prod
- Ensure complete isolation between development and production environments

## Changes
- **New**: `backends/dev.backend.hcl` - Development environment backend config
- **New**: `backends/prod.backend.hcl` - Production environment backend config  
- **Updated**: `versions.tf` - Remove hardcoded backend, use environment-specific configs
- **Updated**: `deploy-dev.sh` - Use dev backend configuration
- **Updated**: `deploy-prod.sh` - Use prod backend configuration
- **Updated**: `README.md` - Document new backend usage pattern

## Test plan
- [ ] Run `./setup-remote-state.sh` to create Azure Storage Account
- [ ] Test development deployment: `./scripts/deploy-dev.sh`
- [ ] Verify dev tfstate is stored at `dev/shift-scheduler.tfstate`
- [ ] Test production deployment: `./scripts/deploy-prod.sh`  
- [ ] Verify prod tfstate is stored at `prod/shift-scheduler.tfstate`
- [ ] Confirm environments are completely isolated

🤖 Generated with [Claude Code](https://claude.ai/code)